### PR TITLE
Fix KPI display and clean up unused code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+dist
+npm-debug.log*

--- a/src/components/KPIs.jsx
+++ b/src/components/KPIs.jsx
@@ -4,7 +4,14 @@ export default function KPIs({ metrics = {} }){
   const items = [
     { key:'decisionTime', label:'Días a decisión', value: metrics.decisionTime ?? '—' },
     { key:'investorsActive', label:'Inversionistas activos', value: metrics.investorsActive ?? '—' },
-    { key:'dealsAccelerated', label:'Deals acelerados', value: metrics.dealsAccelerated ? (metrics.dealsAccelerated+'%') : '—' },
+    {
+      key: 'dealsAccelerated',
+      label: 'Deals acelerados',
+      value:
+        metrics.dealsAccelerated !== null && metrics.dealsAccelerated !== undefined
+          ? metrics.dealsAccelerated + '%'
+          : '—'
+    },
     { key:'nps', label:'NPS', value: metrics.nps ?? '—' },
   ]
   return (

--- a/src/pages/Admin.jsx
+++ b/src/pages/Admin.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import React, { useState } from 'react'
 import { api } from '../lib/api'
 import RoleGate from '../components/RoleGate'
 

--- a/src/pages/Documents.jsx
+++ b/src/pages/Documents.jsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useState } from 'react'
 import { api } from '../lib/api'
-import { identity } from '../lib/identity'
 
 export default function Documents(){
   const [docs, setDocs] = useState([])

--- a/src/pages/Updates.jsx
+++ b/src/pages/Updates.jsx
@@ -9,8 +9,8 @@ export default function Updates(){
     <div className="container">
       <div className="h1">Actualizaciones</div>
       <div className="grid">
-        {items.map((u,i) => (
-          <div key={i} className="card">
+        {items.map((u) => (
+          <div key={u.date} className="card">
             <div className="h2">{u.title}</div>
             <div style={{color:'#8b8b8b'}}>{u.date}</div>
             <p>{u.body}</p>


### PR DESCRIPTION
## Summary
- Show 0% correctly for deals accelerated KPIs
- Remove unused imports and index-based keys
- Add missing .gitignore to ignore build output and dependencies

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c4323ef88483279b7baf1276c5e5bd