### PR TITLE
feat: investor onboarding via admin

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,9 @@ DOCS_BRANCH=main
 
 # Token con permisos de contents:read/write en ambos repos
 GITHUB_TOKEN=ghp_xxx
+
+# Token Admin de Netlify Identity
+IDENTITY_ADMIN_TOKEN=netlify_identity_admin_token
 ```
 
 > Sin `GITHUB_TOKEN`, el sitio funciona en modo demo (lee `/data` local y no lista documentos).
@@ -147,3 +150,11 @@ npm run build # genera /dist
 - **Reportes** (CSV/JSON) desde Functions para métricas trimestrales.
 - **MFA** via Netlify Identity + enforced roles.
 ```)
+
+## 12) Pruebas manuales create-investor
+
+1. **Caso feliz** (dominio nuevo): llenar el formulario en `/admin` con un dominio corporativo y verificar que se crean commits en `data/investor-index.json`, `data/investors/<slug>.json` y las carpetas en el repo de documentos. Debe enviarse la invitación Identity.
+2. **Mapping existente**: repetir con el mismo dominio y confirmar que no falla y los commits retornan `null` donde no hubo cambios.
+3. **Dominio genérico**: usar un correo de `gmail.com`; el slug se deriva del nombre y no se crea mapping.
+4. **Sin permisos**: probar con un usuario sin rol `ri`/`admin` y verificar respuesta 403.
+5. **Falta IDENTITY_ADMIN_TOKEN**: remover la variable y confirmar que la función responde 500 con mensaje claro.

--- a/netlify/functions/create-investor.mjs
+++ b/netlify/functions/create-investor.mjs
@@ -1,0 +1,132 @@
+import { ok, text, requireUser, hasAnyRole } from './_lib/utils.mjs'
+import { repoEnv, getFile, putFile } from './_lib/github.mjs'
+
+function normalizeSlug(s){
+  return (s || '')
+    .normalize('NFD').replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '')
+}
+
+const GENERIC_DOMAINS = new Set([
+  'gmail.com','yahoo.com','hotmail.com','outlook.com','icloud.com',
+  'aol.com','live.com','msn.com','protonmail.com'
+])
+
+export async function handler(event, context){
+  try{
+    const user = requireUser(context)
+    if (!hasAnyRole(user, ['admin','ri'])) return text(403, 'Requiere rol admin o ri')
+
+    const body = JSON.parse(event.body || '{}')
+    if (!body.email || !body.companyName) return text(400, 'Faltan campos obligatorios')
+
+    const status = body.status || 'NDA'
+    const email = body.email.toLowerCase()
+    if (!email.includes('@')) return text(400, 'Email inválido')
+    const domain = email.split('@')[1]
+    const generic = GENERIC_DOMAINS.has(domain)
+
+    let slug = normalizeSlug(body.slug || '')
+    if (!slug){
+      if (generic){
+        slug = normalizeSlug(body.companyName)
+      }else{
+        slug = normalizeSlug(domain.split('.')[0])
+      }
+    }
+
+    const deadlines = body.deadlines || {}
+
+    const contentRepo = repoEnv('CONTENT_REPO', '')
+    const contentBranch = process.env.CONTENT_BRANCH || 'main'
+    const docsRepo = repoEnv('DOCS_REPO', '')
+    const docsBranch = process.env.DOCS_BRANCH || 'main'
+    if (!contentRepo || !docsRepo || !process.env.GITHUB_TOKEN){
+      return text(500, 'CONTENT_REPO/DOCS_REPO/GITHUB_TOKEN no configurados')
+    }
+
+    // Step A: update investor-index.json
+    let indexSha = null
+    if (!generic){
+      const idxPath = 'data/investor-index.json'
+      const idxFile = await getFile(contentRepo, idxPath, contentBranch)
+      const idx = JSON.parse(Buffer.from(idxFile.content, 'base64').toString('utf-8'))
+      const existing = idx.domains[domain]
+      if (existing && existing !== slug) return text(409, `Dominio ${domain} ya mapeado a ${existing}`)
+      const conflict = Object.entries(idx.domains).find(([d,s]) => s === slug && d !== domain)
+      if (conflict) return text(409, `Slug ${slug} ya usado por ${conflict[0]}`)
+      if (!existing){
+        idx.domains[domain] = slug
+        const contentBase64 = Buffer.from(JSON.stringify(idx, null, 2)).toString('base64')
+        const resIdx = await putFile(contentRepo, idxPath, contentBase64, `map(domain -> slug): ${domain} -> ${slug}`, idxFile.sha, contentBranch)
+        indexSha = resIdx.commit && resIdx.commit.sha
+      }
+    }
+
+    // Step B: create/update investor file
+    const invPath = `data/investors/${slug}.json`
+    let invSha
+    try{
+      const f = await getFile(contentRepo, invPath, contentBranch)
+      invSha = f.sha
+    }catch(_){ /* new */ }
+    const investorData = {
+      id: slug,
+      name: body.companyName,
+      status,
+      deadlines,
+      metrics: { decisionTime: 45, investorsActive: 1, dealsAccelerated: 0, nps: 70 }
+    }
+    const invContent = Buffer.from(JSON.stringify(investorData, null, 2)).toString('base64')
+    const resInv = await putFile(contentRepo, invPath, invContent, `create/update investor: ${slug}`, invSha, contentBranch)
+    const investorSha = resInv.commit && resInv.commit.sha
+
+    // Step C: scaffold docs folders
+    const categories = ['NDA','Propuestas','Contratos','LOIs','Sustento fiscal','Mitigación de riesgos','Procesos']
+    let docsSha = null
+    for (const cat of categories){
+      const path = `${cat}/${slug}/.keep`
+      try{
+        await getFile(docsRepo, path, docsBranch)
+      }catch(_){
+        const res = await putFile(docsRepo, path, Buffer.from('').toString('base64'), `scaffold docs folders for ${slug}`, undefined, docsBranch)
+        docsSha = res.commit && res.commit.sha
+      }
+    }
+
+    // Step D: invite via Netlify Identity Admin API
+    const token = process.env.IDENTITY_ADMIN_TOKEN
+    if (!token) return text(500, 'configure IDENTITY_ADMIN_TOKEN')
+    const siteUrl = process.env.SITE_URL || `https://${event.headers.host}`
+    let invite = 'sent'
+    const resId = await fetch(`${siteUrl}/.netlify/identity/admin/users`, {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${token}`,
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({ email, app_metadata: { roles: ['investor'] } })
+    })
+    if (!resId.ok){
+      if (resId.status === 409 || resId.status === 422){
+        invite = 'exists'
+      }else{
+        const msg = await resId.text()
+        throw new Error(`Identity ${resId.status}: ${msg}`)
+      }
+    }
+
+    return ok({
+      ok: true,
+      slug,
+      domain,
+      commits: { index: indexSha, investor: investorSha, docs: docsSha },
+      invite
+    })
+  }catch(err){
+    return text(500, err.message)
+  }
+}

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -29,6 +29,9 @@ export const api = {
   async updateStatus(payload){
     return req('/.netlify/functions/update-status', { method:'POST', body: payload })
   },
+  async createInvestor(payload){
+    return req('/.netlify/functions/create-investor', { method:'POST', body: payload })
+  },
   calendarIcsUrl(slug){
     return `/.netlify/functions/calendar?slug=${encodeURIComponent(slug)}`
   },

--- a/src/pages/Admin.jsx
+++ b/src/pages/Admin.jsx
@@ -20,6 +20,12 @@ export default function Admin({ user }){
   const [msg, setMsg] = useState(null)
   const [err, setErr] = useState(null)
 
+  const [inv, setInv] = useState({ email: '', companyName: '', slug: '', status: 'NDA', deadlines: [{ k: '', v: '' }, { k: '', v: '' }] })
+  const [invMsg, setInvMsg] = useState(null)
+  const [invErr, setInvErr] = useState(null)
+  const [invLoading, setInvLoading] = useState(false)
+  const [progress, setProgress] = useState(0)
+
   const onSubmit = async (e) => {
     e.preventDefault()
     setMsg(null); setErr(null)
@@ -29,16 +35,64 @@ export default function Admin({ user }){
     }catch(error){ setErr(error.message) }
   }
 
+  const setDeadline = (i, field, value) => {
+    const arr = [...inv.deadlines]
+    arr[i] = { ...arr[i], [field]: value }
+    setInv({ ...inv, deadlines: arr })
+  }
+
+  const onCreate = async (e) => {
+    e.preventDefault()
+    setInvMsg(null); setInvErr(null)
+    setInvLoading(true); setProgress(10)
+    try{
+      const dl = {}
+      for (const d of inv.deadlines){ if (d.k && d.v) dl[d.k] = d.v }
+      const payload = { email: inv.email, companyName: inv.companyName, status: inv.status, deadlines: dl }
+      if (inv.slug) payload.slug = inv.slug
+      const res = await api.createInvestor(payload)
+      setProgress(100)
+      setInvMsg(res)
+    }catch(error){ setInvErr(error.message); setProgress(0) }
+    finally{ setInvLoading(false) }
+  }
+
   return (
     <RoleGate user={user} allow={['admin','ri']}>
       <div className="container">
         <div className="h1">Admin / Relaciones con Inversionistas</div>
+        <div className="card" style={{marginBottom:12}}>
+          <div className="h2">Alta de Inversionista</div>
+          <form onSubmit={onCreate}>
+            <div className="form-row">
+              <input className="input" type="email" placeholder="Email corporativo" value={inv.email} onChange={e => setInv({ ...inv, email: e.target.value })} required />
+              <input className="input" placeholder="Nombre de la empresa" value={inv.companyName} onChange={e => setInv({ ...inv, companyName: e.target.value })} required />
+              <input className="input" placeholder="Slug deseado (opcional)" value={inv.slug} onChange={e => setInv({ ...inv, slug: e.target.value })} />
+              <select className="select" value={inv.status} onChange={e => setInv({ ...inv, status: e.target.value })}>
+                {STAGES.map(s => <option key={s}>{s}</option>)}
+              </select>
+            </div>
+            <div style={{marginTop:8}}>
+              {inv.deadlines.map((d, i) => (
+                <div key={i} className="form-row" style={{marginTop:4}}>
+                  <input className="input" placeholder="Clave" value={d.k} onChange={e => setDeadline(i, 'k', e.target.value)} />
+                  <input className="input" type="date" value={d.v} onChange={e => setDeadline(i, 'v', e.target.value)} />
+                </div>
+              ))}
+              <button type="button" className="btn" style={{marginTop:4}} onClick={() => setInv({ ...inv, deadlines: [...inv.deadlines, { k: '', v: '' }] })}>Agregar deadline</button>
+            </div>
+            <button className="btn" type="submit" disabled={invLoading} style={{marginTop:8}}>Crear</button>
+          </form>
+          {invLoading && <div className="progress" style={{marginTop:8}}><div style={{width: progress + '%'}} /></div>}
+          {invMsg && <div className="notice" style={{marginTop:8}}><pre style={{margin:0}}>{JSON.stringify(invMsg, null, 2)}</pre></div>}
+          {invErr && <div className="notice" style={{marginTop:8}}>{invErr}</div>}
+        </div>
         <div className="card">
           <div className="h2">Actualizar estado de inversionista</div>
           <form onSubmit={onSubmit} className="form-row">
-            <input className="input" placeholder="slug (id)" value={payload.id} onChange={e => setPayload({...payload, id:e.target.value})} />
-            <input className="input" placeholder="Nombre" value={payload.name} onChange={e => setPayload({...payload, name:e.target.value})} />
-            <select className="select" value={payload.status} onChange={e => setPayload({...payload, status:e.target.value})}>
+            <input className="input" placeholder="slug (id)" value={payload.id} onChange={e => setPayload({ ...payload, id: e.target.value })} />
+            <input className="input" placeholder="Nombre" value={payload.name} onChange={e => setPayload({ ...payload, name: e.target.value })} />
+            <select className="select" value={payload.status} onChange={e => setPayload({ ...payload, status: e.target.value })}>
               {STAGES.map(s => <option key={s}>{s}</option>)}
             </select>
             <button className="btn" type="submit">Guardar</button>


### PR DESCRIPTION
## Summary
- add create-investor Netlify function to map email domains to slugs, create investor data, scaffold doc folders, and invite users
- extend admin UI with investor onboarding form and API client
- document IDENTITY_ADMIN_TOKEN env var and manual tests

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c43f022a88832783803fab6aa256e7