### PR TITLE
Update header logo to match provided branding

### DIFF
--- a/public/logo.svg
+++ b/public/logo.svg
@@ -1,11 +1,12 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 220 40">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 96" role="img" aria-labelledby="title desc">
+  <title id="title">Finsolar logo</title>
+  <desc id="desc">Rounded stroke with a dot above the lowercase word finsolar in purple.</desc>
   <defs>
     <style>
-      .t{font:800 22px 'Raleway', sans-serif; fill:#161616}
+      .word{font-family:'Raleway', 'Lato', 'Segoe UI', sans-serif;font-weight:700;font-size:64px;fill:#7F4DAB;letter-spacing:0.5px}
     </style>
   </defs>
-  <rect x="0" y="6" width="44" height="28" rx="6" fill="#7F4DAB"/>
-  <path d="M6 28c7-0.6 10.5-4.2 15.4-9.6 4.2-4.2 8.2-7.2 15.6-7.2v5c-5.7 0-9.4 3-14.6 9.2C16 31.9 11 35 4 35z" fill="#F49A00"/>
-  <circle cx="36" cy="12" r="4" fill="white"/>
-  <text x="54" y="27" class="t">Finsolar Dealroom</text>
+  <path d="M32 24c58-18 140-18 208 0" fill="none" stroke="#7F4DAB" stroke-width="6" stroke-linecap="round" />
+  <circle cx="255" cy="18" r="8" fill="#7F4DAB" />
+  <text x="24" y="76" class="word">finsolar</text>
 </svg>


### PR DESCRIPTION
## Summary
- replace the header logo with the provided Finsolar branding so the Dealroom title only appears once

## Testing
- npm run build *(fails: npm is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c8d04052688327b104cfd5c16a31bc