### PR TITLE
Remove calendar subscription option from dashboard

### DIFF
--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -24,12 +24,11 @@ export default function Dashboard(){
 
   return (
     <div className="container">
-      <div className="row" style={{justifyContent:'space-between'}}>
+      <div className="row">
         <div>
           <div className="h1">Panel</div>
           <div style={{color:'#8b8b8b'}}>Visibilidad del roadmap y documentos.</div>
         </div>
-        {investor && <a className="btn secondary" href={api.calendarIcsUrl(investor.id)}>Suscribirse (ICS)</a>}
       </div>
 
       {err && <div className="notice">{err}</div>}


### PR DESCRIPTION
## Summary
- remove the ICS subscription link from the dashboard header
- tidy the dashboard row layout now that the subscription button is gone

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c9552289048327ba90f16a0e750573