### PR TITLE
Show all progress steps under progress bar

### DIFF
--- a/src/components/ProgressBar.jsx
+++ b/src/components/ProgressBar.jsx
@@ -8,10 +8,29 @@ export default function ProgressBar({ stages = [], current = '' }){
       <div className="progress" aria-label="avance">
         <div style={{width: pct+'%'}} />
       </div>
-      <div style={{display:'flex', justifyContent:'space-between', fontSize:12, color:'#8b8b8b', marginTop:6}}>
-        <span>{stages[0]}</span>
-        <span>{current}</span>
-        <span>{stages[stages.length-1]}</span>
+      <div
+        style={{
+          display:'grid',
+          gridTemplateColumns: stages.length ? `repeat(${stages.length}, minmax(0, 1fr))` : undefined,
+          fontSize:12,
+          color:'#8b8b8b',
+          marginTop:6,
+          columnGap:8,
+          rowGap:4
+        }}
+      >
+        {stages.map((stageName, i) => (
+          <span
+            key={stageName + '-' + i}
+            style={{
+              textAlign: i === 0 ? 'left' : i === stages.length-1 ? 'right' : 'center',
+              fontWeight: stageName === current ? 700 : 400,
+              color: stageName === current ? '#161616' : undefined
+            }}
+          >
+            {stageName}
+          </span>
+        ))}
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary
- render labels for each stage beneath the dashboard progress bar instead of only the first, current and last steps
- highlight the active stage label while arranging labels evenly with a responsive grid layout

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c956ba59c8832781c29c0514e9ab92