### PR TITLE
Adjust investor dashboard metrics and next steps

### DIFF
--- a/src/components/KPIs.jsx
+++ b/src/components/KPIs.jsx
@@ -1,19 +1,34 @@
 import React from 'react'
 
-export default function KPIs({ metrics = {} }){
-  const items = [
-    { key:'decisionTime', label:'Días a decisión', value: metrics.decisionTime ?? '—' },
-    { key:'investorsActive', label:'Inversionistas activos', value: metrics.investorsActive ?? '—' },
-    {
-      key: 'dealsAccelerated',
-      label: 'Deals acelerados',
-      value:
-        metrics.dealsAccelerated !== null && metrics.dealsAccelerated !== undefined
-          ? metrics.dealsAccelerated + '%'
-          : '—'
-    },
-    { key:'nps', label:'NPS', value: metrics.nps ?? '—' },
-  ]
+const KPI_DEFINITIONS = [
+  { key:'decisionTime', label:'Días a decisión', format: (value) => value ?? '—' },
+  { key:'investorsActive', label:'Inversionistas activos', format: (value) => value ?? '—' },
+  {
+    key: 'dealsAccelerated',
+    label: 'Deals acelerados',
+    format: (value) =>
+      value !== null && value !== undefined
+        ? value + '%'
+        : '—'
+  },
+  { key:'nps', label:'NPS', format: (value) => value ?? '—' },
+]
+
+export default function KPIs({ metrics = {}, visibleKeys }){
+  const allowed = Array.isArray(visibleKeys) && visibleKeys.length
+    ? new Set(visibleKeys)
+    : null
+
+  const items = KPI_DEFINITIONS
+    .filter(def => !allowed || allowed.has(def.key))
+    .map(def => ({
+      key: def.key,
+      label: def.label,
+      value: def.format(metrics[def.key])
+    }))
+
+  if (!items.length) return null
+
   return (
     <div className="grid">
       {items.map(it => (

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -18,8 +18,10 @@ export default function Dashboard(){
     api.getInvestor().then(setInvestor).catch(e => setErr(e.message))
   }, [])
 
-  const metrics = investor?.metrics || { decisionTime: '—', investorsActive: '—', dealsAccelerated: 0, nps: '—' }
+  const metrics = investor?.metrics || { decisionTime: '—' }
   const stage = investor?.status || STAGES[0]
+  const stageIndex = STAGES.findIndex(s => s === stage)
+  const nextSteps = stageIndex >= 0 ? STAGES.slice(stageIndex + 1) : []
   const deadlines = investor?.deadlines || {}
 
   return (
@@ -47,18 +49,28 @@ export default function Dashboard(){
       </div>
 
       <div style={{marginTop:12}}>
-        <KPIs metrics={metrics} />
+        <KPIs metrics={metrics} visibleKeys={['decisionTime']} />
       </div>
 
       <div className="card" style={{marginTop:12}}>
         <div className="h2">Siguientes pasos</div>
-        <ol>
-          <li>Completar NDA y carpeta de información.</li>
-          <li>Revisar propuesta técnica-financiera y confirmar alcance.</li>
-          <li>Emitir LOI con montos y plazos.</li>
-          <li>Iniciar due diligence y revisión de contratos.</li>
-          <li>Definir cronograma de inversión y firmar.</li>
-        </ol>
+        {stageIndex < 0 && (
+          <p style={{color:'#8b8b8b', marginBottom:0}}>
+            No hay pasos siguientes configurados para la etapa actual.
+          </p>
+        )}
+        {stageIndex >= 0 && nextSteps.length === 0 && (
+          <p style={{color:'#8b8b8b', marginBottom:0}}>
+            Has completado todas las etapas del proceso.
+          </p>
+        )}
+        {nextSteps.length > 0 && (
+          <ol>
+            {nextSteps.map(step => (
+              <li key={step}>{step}</li>
+            ))}
+          </ol>
+        )}
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary
- limit investor dashboard KPIs to the decision time metric while keeping component flexibility
- derive "Siguientes pasos" directly from the current stage and surface completion/fallback messaging

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c95abfc2108327add1552057e2af33