### PR TITLE
Improve KPI card layout to prevent overflow

### DIFF
--- a/data/investors/femsa.json
+++ b/data/investors/femsa.json
@@ -8,6 +8,19 @@
   },
   "metrics": {
     "decisionTime": 35,
+    "fiscalCapitalInvestment": 20000000,
+    "projectProfitability": {
+      "amount": 12500000,
+      "years": 7
+    },
+    "portfolio": {
+      "type": "mix",
+      "mix": {
+        "solarFarms": 40,
+        "aaaCompanies": 35,
+        "ownSites": 25
+      }
+    },
     "investorsActive": 12,
     "dealsAccelerated": 38,
     "nps": 72

--- a/src/components/KPIs.jsx
+++ b/src/components/KPIs.jsx
@@ -1,7 +1,88 @@
 import React from 'react'
 
+const currencyFormatter = new Intl.NumberFormat('es-MX', {
+  style: 'currency',
+  currency: 'USD',
+  maximumFractionDigits: 0
+})
+
+const formatCurrency = (value) => {
+  if (value === null || value === undefined || value === '') return '—'
+  const num = typeof value === 'string' ? Number(value) : value
+  if (Number.isNaN(num)) return '—'
+  return currencyFormatter.format(num)
+}
+
+const formatProjectProfitability = (value) => {
+  if (!value || typeof value !== 'object') return '—'
+  const amountLabel = formatCurrency(value.amount)
+  const parts = []
+  if (amountLabel !== '—') parts.push(amountLabel)
+
+  const yearsRaw = value.years
+  if (yearsRaw !== null && yearsRaw !== undefined && yearsRaw !== ''){
+    const yearsNum = typeof yearsRaw === 'string' ? Number(yearsRaw) : yearsRaw
+    const isValidNumber = !Number.isNaN(yearsNum) && yearsNum > 0
+    if (isValidNumber){
+      parts.push(`a ${yearsNum} ${yearsNum === 1 ? 'año' : 'años'}`)
+    }
+  }
+
+  return parts.length ? parts.join(' ') : '—'
+}
+
+const PORTFOLIO_LABELS = {
+  solarFarms: 'Granjas Solares',
+  aaaCompanies: 'Empresas AAA',
+  ownSites: 'Sitios Propios',
+  mix: 'Mix'
+}
+
+const formatPortfolio = (value) => {
+  if (!value) return '—'
+  if (typeof value === 'string') return value
+
+  const type = value.type
+  if (!type) return '—'
+
+  if (type === 'mix'){
+    const mix = value.mix || {}
+    const parts = [
+      ['solarFarms', PORTFOLIO_LABELS.solarFarms],
+      ['aaaCompanies', PORTFOLIO_LABELS.aaaCompanies],
+      ['ownSites', PORTFOLIO_LABELS.ownSites]
+    ]
+      .map(([key, label]) => {
+        const v = mix[key]
+        if (v === null || v === undefined || v === '') return null
+        return `${v}% ${label}`
+      })
+      .filter(Boolean)
+
+    if (!parts.length) return 'Mix'
+    return `Mix: ${parts.join(' / ')}`
+  }
+
+  return PORTFOLIO_LABELS[type] || type
+}
+
 const KPI_DEFINITIONS = [
   { key:'decisionTime', label:'Días a decisión', format: (value) => value ?? '—' },
+  {
+    key: 'fiscalCapitalInvestment',
+    label: 'Inversión de capital fiscal',
+    format: formatCurrency
+  },
+  {
+    key: 'projectProfitability',
+    label: 'Utilidad de proyecto',
+    format: formatProjectProfitability
+  },
+  {
+    key: 'portfolio',
+    label: 'Portafolio',
+    format: formatPortfolio
+  },
   { key:'investorsActive', label:'Inversionistas activos', format: (value) => value ?? '—' },
   {
     key: 'dealsAccelerated',
@@ -33,8 +114,8 @@ export default function KPIs({ metrics = {}, visibleKeys }){
     <div className="grid">
       {items.map(it => (
         <div className="card kpi" key={it.key}>
-          <div className="num">{it.value}</div>
           <div className="label">{it.label}</div>
+          <div className="num">{it.value}</div>
         </div>
       ))}
     </div>

--- a/src/pages/Admin.jsx
+++ b/src/pages/Admin.jsx
@@ -9,13 +9,43 @@ const STAGES = [
   "Cronograma de inversión","Firma de contratos"
 ]
 
+const PORTFOLIO_OPTIONS = [
+  { value: 'solarFarms', label: 'Granjas Solares' },
+  { value: 'aaaCompanies', label: 'Empresas AAA' },
+  { value: 'ownSites', label: 'Sitios Propios' },
+  { value: 'mix', label: 'Mix' }
+]
+
+const MIX_FIELDS = [
+  { key: 'solarFarms', label: 'Granjas Solares' },
+  { key: 'aaaCompanies', label: 'Empresas AAA' },
+  { key: 'ownSites', label: 'Sitios Propios' }
+]
+
+const parseNumber = (value) => {
+  if (value === null || value === undefined || value === '') return null
+  const num = Number(value)
+  return Number.isNaN(num) ? null : num
+}
+
 export default function Admin({ user }){
   const [payload, setPayload] = useState({
     id: 'femsa',
     name: 'FEMSA',
     status: 'LOI',
     deadlines: { 'LOI':'2025-10-15', 'Firma':'2025-11-30' },
-    metrics: { decisionTime: 35, investorsActive: 12, dealsAccelerated: 38, nps: 72 }
+    metrics: {
+      decisionTime: 35,
+      fiscalCapitalInvestment: 20000000,
+      projectProfitability: { amount: 12500000, years: 7 },
+      portfolio: {
+        type: 'mix',
+        mix: { solarFarms: 40, aaaCompanies: 35, ownSites: 25 }
+      },
+      investorsActive: 12,
+      dealsAccelerated: 38,
+      nps: 72
+    }
   })
   const [msg, setMsg] = useState(null)
   const [err, setErr] = useState(null)
@@ -26,11 +56,117 @@ export default function Admin({ user }){
   const [invLoading, setInvLoading] = useState(false)
   const [progress, setProgress] = useState(0)
 
+  const metrics = payload.metrics || {}
+
+  const updateMetric = (key, updater) => {
+    setPayload(prev => {
+      const prevMetrics = prev.metrics || {}
+      const nextValue = typeof updater === 'function'
+        ? updater(prevMetrics[key])
+        : updater
+      return { ...prev, metrics: { ...prevMetrics, [key]: nextValue } }
+    })
+  }
+
+  const handlePortfolioTypeChange = (type) => {
+    updateMetric('portfolio', current => {
+      const next = { type }
+      if (type === 'mix'){
+        const prevMix = current && current.type === 'mix' && current.mix ? current.mix : {}
+        next.mix = {
+          solarFarms: prevMix.solarFarms ?? '',
+          aaaCompanies: prevMix.aaaCompanies ?? '',
+          ownSites: prevMix.ownSites ?? ''
+        }
+      }
+      return next
+    })
+  }
+
+  const handleMixChange = (field, value) => {
+    updateMetric('portfolio', current => {
+      const base = current && current.type === 'mix'
+        ? current
+        : { type: 'mix', mix: { solarFarms: '', aaaCompanies: '', ownSites: '' } }
+      return {
+        ...base,
+        mix: {
+          ...(base.mix || {}),
+          [field]: value
+        }
+      }
+    })
+  }
+
+  const portfolio = metrics.portfolio || {}
+  const isPortfolioMix = portfolio.type === 'mix'
+  const mixValues = isPortfolioMix
+    ? {
+        solarFarms: portfolio.mix?.solarFarms ?? '',
+        aaaCompanies: portfolio.mix?.aaaCompanies ?? '',
+        ownSites: portfolio.mix?.ownSites ?? ''
+      }
+    : { solarFarms: '', aaaCompanies: '', ownSites: '' }
+  const mixTotal = isPortfolioMix
+    ? MIX_FIELDS.reduce((sum, field) => {
+        const raw = mixValues[field.key]
+        const num = Number(raw)
+        return sum + (Number.isNaN(num) ? 0 : num)
+      }, 0)
+    : 0
+  const projectProfitability = metrics.projectProfitability || {}
+
+  const labelStyle = { fontSize: 12, fontWeight: 700, color: 'var(--muted)', marginBottom: 4 }
+  const fieldStyle = { display: 'flex', flexDirection: 'column', flex: 1, minWidth: 200 }
+  const mixFieldStyle = { display: 'flex', flexDirection: 'column', flex: 1, minWidth: 160 }
+
   const onSubmit = async (e) => {
     e.preventDefault()
     setMsg(null); setErr(null)
     try{
-      await api.updateStatus(payload)
+      const metricsPayload = payload.metrics || {}
+      const normalizedMetrics = {
+        ...metricsPayload,
+        decisionTime: parseNumber(metricsPayload.decisionTime),
+        fiscalCapitalInvestment: parseNumber(metricsPayload.fiscalCapitalInvestment)
+      }
+
+      if (metricsPayload.investorsActive !== undefined){
+        normalizedMetrics.investorsActive = parseNumber(metricsPayload.investorsActive)
+      }
+      if (metricsPayload.dealsAccelerated !== undefined){
+        normalizedMetrics.dealsAccelerated = parseNumber(metricsPayload.dealsAccelerated)
+      }
+      if (metricsPayload.nps !== undefined){
+        normalizedMetrics.nps = parseNumber(metricsPayload.nps)
+      }
+
+      const profitRaw = metricsPayload.projectProfitability || {}
+      const profitAmount = parseNumber(profitRaw.amount)
+      const profitYears = parseNumber(profitRaw.years)
+      normalizedMetrics.projectProfitability = (profitAmount === null && profitYears === null)
+        ? null
+        : { amount: profitAmount, years: profitYears }
+
+      const portfolioRaw = metricsPayload.portfolio
+      if (!portfolioRaw || !portfolioRaw.type){
+        normalizedMetrics.portfolio = null
+      }else if (portfolioRaw.type === 'mix'){
+        const mixRaw = portfolioRaw.mix || {}
+        const normalizedMix = MIX_FIELDS.reduce((acc, field) => {
+          const parsed = parseNumber(mixRaw[field.key])
+          if (parsed !== null){
+            acc[field.key] = parsed
+          }
+          return acc
+        }, {})
+        normalizedMetrics.portfolio = { type: 'mix', mix: normalizedMix }
+      }else{
+        normalizedMetrics.portfolio = { type: portfolioRaw.type }
+      }
+
+      const payloadToSend = { ...payload, metrics: normalizedMetrics }
+      await api.updateStatus(payloadToSend)
       setMsg('Guardado y commiteado a GitHub.')
     }catch(error){ setErr(error.message) }
   }
@@ -95,13 +231,124 @@ export default function Admin({ user }){
         </div>
         <div className="card">
           <div className="h2">Actualizar estado de inversionista</div>
-          <form onSubmit={onSubmit} className="form-row">
-            <input className="input" placeholder="slug (id)" value={payload.id} onChange={e => setPayload({ ...payload, id: e.target.value })} />
-            <input className="input" placeholder="Nombre" value={payload.name} onChange={e => setPayload({ ...payload, name: e.target.value })} />
-            <select className="select" value={payload.status} onChange={e => setPayload({ ...payload, status: e.target.value })}>
-              {STAGES.map(s => <option key={s}>{s}</option>)}
-            </select>
-            <button className="btn" type="submit">Guardar</button>
+          <form onSubmit={onSubmit}>
+            <div className="form-row">
+              <input
+                className="input"
+                placeholder="slug (id)"
+                value={payload.id}
+                onChange={e => setPayload({ ...payload, id: e.target.value })}
+              />
+              <input
+                className="input"
+                placeholder="Nombre"
+                value={payload.name}
+                onChange={e => setPayload({ ...payload, name: e.target.value })}
+              />
+              <select
+                className="select"
+                value={payload.status}
+                onChange={e => setPayload({ ...payload, status: e.target.value })}
+              >
+                {STAGES.map(s => <option key={s}>{s}</option>)}
+              </select>
+            </div>
+
+            <div style={{ marginTop: 12, fontWeight: 700 }}>Métricas clave</div>
+
+            <div className="form-row" style={{ marginTop: 8 }}>
+              <div style={fieldStyle}>
+                <label htmlFor="metric-decisionTime" style={labelStyle}>Días a decisión</label>
+                <input
+                  id="metric-decisionTime"
+                  className="input"
+                  type="number"
+                  min="0"
+                  value={metrics.decisionTime ?? ''}
+                  onChange={e => updateMetric('decisionTime', e.target.value)}
+                />
+              </div>
+              <div style={fieldStyle}>
+                <label htmlFor="metric-fiscal" style={labelStyle}>Inversión de capital fiscal ($)</label>
+                <input
+                  id="metric-fiscal"
+                  className="input"
+                  type="number"
+                  min="0"
+                  step="any"
+                  value={metrics.fiscalCapitalInvestment ?? ''}
+                  onChange={e => updateMetric('fiscalCapitalInvestment', e.target.value)}
+                />
+              </div>
+            </div>
+
+            <div className="form-row" style={{ marginTop: 8 }}>
+              <div style={fieldStyle}>
+                <label htmlFor="metric-project-amount" style={labelStyle}>Utilidad de proyecto ($)</label>
+                <input
+                  id="metric-project-amount"
+                  className="input"
+                  type="number"
+                  min="0"
+                  step="any"
+                  value={projectProfitability.amount ?? ''}
+                  onChange={e => updateMetric('projectProfitability', current => ({ ...(current || {}), amount: e.target.value }))}
+                />
+              </div>
+              <div style={fieldStyle}>
+                <label htmlFor="metric-project-years" style={labelStyle}>Horizonte (años)</label>
+                <input
+                  id="metric-project-years"
+                  className="input"
+                  type="number"
+                  min="0"
+                  value={projectProfitability.years ?? ''}
+                  onChange={e => updateMetric('projectProfitability', current => ({ ...(current || {}), years: e.target.value }))}
+                />
+              </div>
+            </div>
+
+            <div className="form-row" style={{ marginTop: 8 }}>
+              <div style={fieldStyle}>
+                <label htmlFor="metric-portfolio-type" style={labelStyle}>Portafolio</label>
+                <select
+                  id="metric-portfolio-type"
+                  className="select"
+                  value={portfolio.type || ''}
+                  onChange={e => handlePortfolioTypeChange(e.target.value)}
+                >
+                  <option value="">Selecciona una opción</option>
+                  {PORTFOLIO_OPTIONS.map(opt => (
+                    <option key={opt.value} value={opt.value}>{opt.label}</option>
+                  ))}
+                </select>
+              </div>
+            </div>
+
+            {isPortfolioMix && (
+              <div style={{ marginTop: 8 }}>
+                <div className="form-row">
+                  {MIX_FIELDS.map(field => (
+                    <div key={field.key} style={mixFieldStyle}>
+                      <label htmlFor={`metric-portfolio-${field.key}`} style={labelStyle}>{field.label} (%)</label>
+                      <input
+                        id={`metric-portfolio-${field.key}`}
+                        className="input"
+                        type="number"
+                        min="0"
+                        max="100"
+                        step="any"
+                        value={mixValues[field.key] ?? ''}
+                        onChange={e => handleMixChange(field.key, e.target.value)}
+                      />
+                    </div>
+                  ))}
+                </div>
+                <div style={{ marginTop: 4, fontSize: 12, color: 'var(--muted)' }}>Suma: {mixTotal}%</div>
+              </div>
+            )}
+
+            <button className="btn" type="submit" style={{ marginTop: 12 }}>Guardar</button>
           </form>
           {msg && <div className="notice" style={{marginTop:8}}>{msg}</div>}
           {err && <div className="notice" style={{marginTop:8}}>{err}</div>}

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -18,7 +18,7 @@ export default function Dashboard(){
     api.getInvestor().then(setInvestor).catch(e => setErr(e.message))
   }, [])
 
-  const metrics = investor?.metrics || { decisionTime: '—' }
+  const metrics = investor?.metrics || {}
   const stage = investor?.status || STAGES[0]
   const stageIndex = STAGES.findIndex(s => s === stage)
   const nextSteps = stageIndex >= 0 ? STAGES.slice(stageIndex + 1) : []
@@ -49,7 +49,10 @@ export default function Dashboard(){
       </div>
 
       <div style={{marginTop:12}}>
-        <KPIs metrics={metrics} visibleKeys={['decisionTime']} />
+        <KPIs
+          metrics={metrics}
+          visibleKeys={['decisionTime','fiscalCapitalInvestment','projectProfitability','portfolio']}
+        />
       </div>
 
       <div className="card" style={{marginTop:12}}>

--- a/src/styles.css
+++ b/src/styles.css
@@ -54,9 +54,27 @@ a:hover{text-decoration:underline}
 
 .h1{font-family:'Raleway',sans-serif; font-size:28px; margin:8px 0 16px}
 .h2{font-family:'Raleway',sans-serif; font-size:20px; margin:12px 0 8px}
-.kpi{display:flex; gap:16px; align-items:center}
-.kpi .num{font-size:28px; font-weight:800; font-family:'Raleway',sans-serif;}
-.kpi .label{color:var(--muted)}
+.kpi{
+  display:flex;
+  flex-direction:column;
+  gap:12px;
+  align-items:flex-start;
+}
+.kpi .num{
+  font-size:28px;
+  font-weight:800;
+  font-family:'Raleway',sans-serif;
+  line-height:1.2;
+  word-break:break-word;
+  overflow-wrap:anywhere;
+}
+.kpi .label{
+  color:var(--muted);
+  font-size:14px;
+  font-weight:600;
+  text-transform:none;
+  letter-spacing:0;
+}
 
 .progress{
   width:100%; background:#eee; border-radius:999px; overflow:hidden; height:10px; border:1px solid var(--border);


### PR DESCRIPTION
## Summary
- reorder KPI card content to show labels above values for clearer stacking
- update KPI styling to use column layout and flexible wrapping so long values stay within the card

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c95fef4eac83278fbe59e7872d72bb