### PR TITLE
Preserve investor query across navigation

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Routes, Route, NavLink } from 'react-router-dom'
+import { Routes, Route, NavLink, useLocation } from 'react-router-dom'
 import Dashboard from './pages/Dashboard'
 import Documents from './pages/Documents'
 import Projects from './pages/Projects'
@@ -9,6 +9,13 @@ import NotFound from './pages/NotFound'
 import './styles.css'
 
 export default function App(){
+  const location = useLocation()
+  const search = location.search
+
+  function withSearch(pathname){
+    return { pathname, search }
+  }
+
   return (
     <>
       <header className="header">
@@ -18,11 +25,11 @@ export default function App(){
             <span>Dealroom</span>
           </div>
           <nav className="nav">
-            <NavLink to="/" end className={({isActive}) => isActive ? 'active' : undefined}>Panel</NavLink>
-            <NavLink to="/projects" className={({isActive}) => isActive ? 'active' : undefined}>Proyectos</NavLink>
-            <NavLink to="/documents" className={({isActive}) => isActive ? 'active' : undefined}>Documentos</NavLink>
-            <NavLink to="/updates" className={({isActive}) => isActive ? 'active' : undefined}>Updates</NavLink>
-            <NavLink to="/admin" className={({isActive}) => isActive ? 'active' : undefined}>Admin</NavLink>
+            <NavLink to={withSearch('/')} end className={({isActive}) => isActive ? 'active' : undefined}>Panel</NavLink>
+            <NavLink to={withSearch('/projects')} className={({isActive}) => isActive ? 'active' : undefined}>Proyectos</NavLink>
+            <NavLink to={withSearch('/documents')} className={({isActive}) => isActive ? 'active' : undefined}>Documentos</NavLink>
+            <NavLink to={withSearch('/updates')} className={({isActive}) => isActive ? 'active' : undefined}>Updates</NavLink>
+            <NavLink to={withSearch('/admin')} className={({isActive}) => isActive ? 'active' : undefined}>Admin</NavLink>
           </nav>
         </div>
       </header>

--- a/src/components/ProjectCard.jsx
+++ b/src/components/ProjectCard.jsx
@@ -1,6 +1,11 @@
 import React from 'react'
+import { useLocation } from 'react-router-dom'
 
 export default function ProjectCard({ p }){
+  const location = useLocation()
+  const search = location.search
+  const documentsHref = `#/documents${search || ''}`
+
   return (
     <div className="card">
       <div className="row" style={{justifyContent:'space-between'}}>
@@ -19,7 +24,7 @@ export default function ProjectCard({ p }){
       {p.notes && <div className="notice" style={{marginTop:10}}>{p.notes}</div>}
       <div style={{display:'flex', gap:8, marginTop:12}}>
         {p.loi_template && <a className="btn secondary" href={p.loi_template} target="_blank" rel="noreferrer">Descargar LOI</a>}
-        <a className="btn" href="#/documents">Ver documentos</a>
+        <a className="btn" href={documentsHref}>Ver documentos</a>
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary
- preserve the current query string when using the main navigation so the investor slug remains scoped
- update project cards to link to the documents page with the active search parameters

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c99265bc3c8327a1622b7e22cc74f1