### PR TITLE
Handle investor slug via path

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -7,14 +7,12 @@ import Admin from './pages/Admin'
 import Updates from './pages/Updates'
 import NotFound from './pages/NotFound'
 import './styles.css'
+import { useInvestorProfile } from './lib/investor'
 
 export default function App(){
   const location = useLocation()
   const search = location.search
-  const searchParams = React.useMemo(() => new URLSearchParams(search), [search])
-  const investorSlug = (searchParams.get('investor') || '').trim()
-  const envInvestorId = (import.meta.env.VITE_PUBLIC_INVESTOR_ID || '').trim()
-  const isInvestorProfile = Boolean(investorSlug || envInvestorId)
+  const { isInvestorProfile } = useInvestorProfile()
 
   function withSearch(pathname){
     return { pathname, search }

--- a/src/lib/investor.js
+++ b/src/lib/investor.js
@@ -1,0 +1,46 @@
+import React from 'react'
+import { useSearchParams } from 'react-router-dom'
+import { DEFAULT_INVESTOR_ID } from './config'
+
+const normalizeSlug = (value) => (value || '').trim().toLowerCase()
+
+const ENV_INVESTOR_SLUG = normalizeSlug(import.meta.env.VITE_PUBLIC_INVESTOR_ID)
+
+const getPathSegments = () => {
+  if (typeof window === 'undefined') return []
+  return window.location.pathname
+    .split('/')
+    .map((segment) => segment.trim())
+    .filter(Boolean)
+}
+
+const getPathSlug = () => {
+  const segments = getPathSegments()
+  if (segments.length === 0) return ''
+  if (segments.length === 1 && segments[0].toLowerCase() === 'i') return ''
+  const candidate = segments[segments.length - 1]
+  if (!candidate || candidate.includes('.')) return ''
+  return normalizeSlug(candidate)
+}
+
+export function useInvestorProfile(){
+  const [searchParams] = useSearchParams()
+  const searchSlug = React.useMemo(
+    () => normalizeSlug(searchParams.get('investor')),
+    [searchParams]
+  )
+  const pathSlug = React.useMemo(() => getPathSlug(), [])
+
+  return React.useMemo(() => {
+    if (searchSlug){
+      return { investorId: searchSlug, source: 'search', isInvestorProfile: true }
+    }
+    if (pathSlug){
+      return { investorId: pathSlug, source: 'path', isInvestorProfile: true }
+    }
+    if (ENV_INVESTOR_SLUG){
+      return { investorId: ENV_INVESTOR_SLUG, source: 'env', isInvestorProfile: true }
+    }
+    return { investorId: DEFAULT_INVESTOR_ID, source: 'default', isInvestorProfile: false }
+  }, [pathSlug, searchSlug])
+}

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -1,9 +1,8 @@
 import React, { useEffect, useState } from 'react'
-import { useSearchParams } from 'react-router-dom'
 import { api } from '../lib/api'
 import ProgressBar from '../components/ProgressBar'
 import KPIs from '../components/KPIs'
-import { DEFAULT_INVESTOR_ID } from '../lib/config'
+import { useInvestorProfile } from '../lib/investor'
 
 const STAGES = [
   "Primera reunión","NDA","Entrega de información","Generación de propuesta",
@@ -15,9 +14,7 @@ const STAGES = [
 export default function Dashboard(){
   const [investor, setInvestor] = useState(null)
   const [err, setErr] = useState(null)
-  const [searchParams] = useSearchParams()
-  const searchSlug = searchParams.get('investor')
-  const investorId = (searchSlug && searchSlug.trim().toLowerCase()) || DEFAULT_INVESTOR_ID
+  const { investorId } = useInvestorProfile()
 
   useEffect(() => {
     let cancelled = false

--- a/src/pages/Documents.jsx
+++ b/src/pages/Documents.jsx
@@ -1,16 +1,13 @@
 import React, { useEffect, useState } from 'react'
-import { useSearchParams } from 'react-router-dom'
 import { api } from '../lib/api'
-import { DEFAULT_INVESTOR_ID } from '../lib/config'
+import { useInvestorProfile } from '../lib/investor'
 
 export default function Documents(){
   const [docs, setDocs] = useState([])
   const [loading, setLoading] = useState(false)
   const [category, setCategory] = useState('NDA')
   const [error, setError] = useState(null)
-  const [searchParams] = useSearchParams()
-  const searchSlug = searchParams.get('investor')
-  const investorId = (searchSlug && searchSlug.trim().toLowerCase()) || DEFAULT_INVESTOR_ID
+  const { investorId } = useInvestorProfile()
 
   async function load(){
     try{


### PR DESCRIPTION
## Summary
- add a shared `useInvestorProfile` hook to resolve investor slugs from query parameters, the URL path, or environment variables
- update the main app navigation to rely on the hook so the Admin area hides on investor-specific slugs
- use the resolved investor id when loading dashboard data and documents so slug-only URLs fetch the right records

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c9adb37c78832795943d25ae5a1142