### PR TITLE
Set application background to white

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -3,7 +3,7 @@
   --orange:#F49A00;
   --black:#161616;
   --white:#FFFFFF;
-  --bg:#000000;
+  --bg:#FFFFFF;
   --muted:#8b8b8b;
   --card:#ffffff;
   --border:#e9e9ef;
@@ -14,7 +14,7 @@ html,body,#root{height:100%}
 body{
   margin:0;
   font-family:'Lato',system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,Cantarell,'Helvetica Neue',Arial,sans-serif;
-  color:var(--white);
+  color:var(--black);
   background:var(--bg);
 }
 


### PR DESCRIPTION
## Summary
- switch the global background color token to white
- update the body text color to the primary black tone to preserve readability

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cc6e4989f0832dbb713f2fbf5004fc