### PR TITLE
Normaliza slug al actualizar inversionistas

### DIFF
--- a/src/pages/Admin.jsx
+++ b/src/pages/Admin.jsx
@@ -398,6 +398,11 @@ export default function Admin({ user }){
     e.preventDefault()
     setMsg(null); setErr(null)
     try{
+      const normalizedId = normalizeSlug(payload.id)
+      if (!normalizedId){
+        throw new Error('El slug (id) es requerido')
+      }
+
       const metricsPayload = payload.metrics || {}
       const normalizedMetrics = {
         ...metricsPayload,
@@ -439,8 +444,18 @@ export default function Admin({ user }){
         normalizedMetrics.portfolio = { type: portfolioRaw.type }
       }
 
-      const payloadToSend = { ...payload, metrics: normalizedMetrics }
+      const normalizedName = typeof payload.name === 'string'
+        ? payload.name.trim()
+        : ''
+      const payloadToSend = {
+        ...payload,
+        id: normalizedId,
+        name: normalizedName,
+        metrics: normalizedMetrics
+      }
+
       await api.updateStatus(payloadToSend)
+      setPayload(payloadToSend)
       setMsg('Guardado y commiteado a GitHub.')
     }catch(error){ setErr(error.message) }
   }


### PR DESCRIPTION
## Summary
- normalizar el slug antes de guardar cambios desde Admin para evitar commits con IDs inconsistentes
- asegurar que la función serverless almacene el archivo en la ruta normalizada y que el contenido incluya el slug limpio
- actualizar el estado local del formulario tras guardar para reflejar los valores normalizados

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cc77a61b9c832d8643514e1da89ea0