### PR TITLE
Add deadline labels in admin investor form

### DIFF
--- a/src/pages/Admin.jsx
+++ b/src/pages/Admin.jsx
@@ -500,9 +500,38 @@ export default function Admin({ user }){
             </div>
             <div style={{marginTop:8}}>
               {inv.deadlines.map((d, i) => (
-                <div key={i} className="form-row" style={{marginTop:4}}>
-                  <input className="input" placeholder="Nombre de la etapa de proceso" value={d.k} onChange={e => setDeadline(i, 'k', e.target.value)} />
-                  <input className="input" type="date" value={d.v} onChange={e => setDeadline(i, 'v', e.target.value)} />
+                <div key={i} className="form-row" style={{ marginTop: 4 }}>
+                  <div style={fieldStyle}>
+                    <label
+                      htmlFor={`deadline-stage-${i}`}
+                      style={labelStyle}
+                    >
+                      Etapa del proceso
+                    </label>
+                    <input
+                      id={`deadline-stage-${i}`}
+                      className="input"
+                      placeholder="Nombre de la etapa de proceso"
+                      value={d.k}
+                      onChange={e => setDeadline(i, 'k', e.target.value)}
+                    />
+                  </div>
+                  <div style={fieldStyle}>
+                    <label
+                      htmlFor={`deadline-date-${i}`}
+                      style={labelStyle}
+                    >
+                      Fecha límite
+                    </label>
+                    <input
+                      id={`deadline-date-${i}`}
+                      className="input"
+                      type="date"
+                      name={`fecha-limite-${i}`}
+                      value={d.v}
+                      onChange={e => setDeadline(i, 'v', e.target.value)}
+                    />
+                  </div>
                 </div>
               ))}
               <button type="button" className="btn" style={{marginTop:4}} onClick={() => setInv({ ...inv, deadlines: [...inv.deadlines, { k: '', v: '' }] })}>Agregar deadline</button>


### PR DESCRIPTION
## Summary
- add explicit labels for the investor deadline form fields in the admin page
- name the date inputs Fecha límite while keeping them as date pickers for accessibility and clarity

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cc8b441ea0832d8666653a591afd41