### PR TITLE
Add document shortcuts to upcoming deadline alerts

### DIFF
--- a/src/lib/deadlines.js
+++ b/src/lib/deadlines.js
@@ -1,0 +1,23 @@
+const DEADLINE_DOC_RULES = [
+  { pattern: /(firma|contrato)/i, category: 'Contratos' },
+  { pattern: /loi/i, category: 'LOIs' },
+  { pattern: /nda/i, category: 'NDA' },
+  { pattern: /propuesta/i, category: 'Propuestas' }
+]
+
+export const DEADLINE_DOC_CATEGORIES = Array.from(new Set(DEADLINE_DOC_RULES.map(rule => rule.category)))
+
+export function resolveDeadlineDocTarget(label){
+  const text = typeof label === 'string' ? label : String(label || '')
+  if (!text.trim()) return null
+  const normalized = text.toLowerCase()
+  for (const rule of DEADLINE_DOC_RULES){
+    if (rule.pattern.test(normalized)){
+      return {
+        category: rule.category,
+        target: 'upload'
+      }
+    }
+  }
+  return null
+}


### PR DESCRIPTION
## Summary
- add a shared helper to map deadline labels to document categories
- update admin and updates deadline alerts to show investor context and link straight to the right document section

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d15182bfbc832db3ce0d2e37b08d77