### PR TITLE
Update currency displays to MXN

### DIFF
--- a/src/components/KPIs.jsx
+++ b/src/components/KPIs.jsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 const currencyFormatter = new Intl.NumberFormat('es-MX', {
   style: 'currency',
-  currency: 'USD',
+  currency: 'MXN',
   maximumFractionDigits: 0
 })
 

--- a/src/pages/Admin.jsx
+++ b/src/pages/Admin.jsx
@@ -1557,7 +1557,7 @@ const [activityRefreshKey, setActivityRefreshKey] = useState(0);
                 />
               </div>
               <div style={fieldStyle}>
-                <label htmlFor="metric-fiscal" style={labelStyle}>Inversión de capital fiscal ($)</label>
+                <label htmlFor="metric-fiscal" style={labelStyle}>Inversión de capital fiscal (MXN)</label>
                 <input
                   id="metric-fiscal"
                   className="input"
@@ -1572,7 +1572,7 @@ const [activityRefreshKey, setActivityRefreshKey] = useState(0);
 
             <div className="form-row" style={{ marginTop: 8 }}>
               <div style={fieldStyle}>
-                <label htmlFor="metric-project-amount" style={labelStyle}>Utilidad de proyecto ($)</label>
+                <label htmlFor="metric-project-amount" style={labelStyle}>Utilidad de proyecto (MXN)</label>
                 <input
                   id="metric-project-amount"
                   className="input"


### PR DESCRIPTION
## Summary
- switch KPI currency formatter to display MXN amounts
- update admin metric labels to reference MXN values

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d2a2d2423c832dbc7e2232d7eaabbf