### PR TITLE
feat: align pipeline and documents ordering

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ VITE_PUBLIC_INVESTOR_ID=femsa
 - Etapas fijas (editable en código):
   1. Primera reunión → 2. NDA → 3. Entrega de información → 4. Generación de propuesta →
   5. Presentación de propuesta → 6. Ajustes técnicos → 7. LOI →
-  8. Due diligence fiscal/financiero/riesgos → 9. Revisión de contratos →
+  8. Revisión de contratos → 9. Due diligence fiscal/financiero/riesgos →
   10. Cronograma de inversión → 11. Firma de contratos
 - Fechas límite por etapa se guardan en `data/investors/<slug>.json` (o en el repo de contenido vía función).
 - Botón **ICS** genera un calendario descargable (sin servicios externos).

--- a/src/constants/documents.js
+++ b/src/constants/documents.js
@@ -1,0 +1,14 @@
+export const DOCUMENT_SECTIONS_ORDER = [
+  'NDA',
+  'Propuestas',
+  'Modelos financieros',
+  'Contratos',
+  'LOIs',
+  'Sustento fiscal',
+  'Mitigación de riesgos',
+  'Procesos'
+]
+
+export const DEFAULT_DOC_CATEGORY = DOCUMENT_SECTIONS_ORDER[0]
+
+export const DASHBOARD_DOC_CATEGORIES = ['NDA', 'Propuestas', 'Contratos']

--- a/src/constants/pipeline.js
+++ b/src/constants/pipeline.js
@@ -1,0 +1,15 @@
+export const PIPELINE_STAGES = [
+  'Primera reunión',
+  'NDA',
+  'Entrega de información',
+  'Generación de propuesta',
+  'Presentación de propuesta',
+  'Ajustes técnicos',
+  'LOI',
+  'Revisión de contratos',
+  'Due diligence fiscal/financiero/riesgos',
+  'Cronograma de inversión',
+  'Firma de contratos'
+]
+
+export const FINAL_PIPELINE_STAGE = PIPELINE_STAGES[PIPELINE_STAGES.length - 1] || ''

--- a/src/pages/Admin.jsx
+++ b/src/pages/Admin.jsx
@@ -3,13 +3,8 @@ import { api } from '../lib/api'
 import RoleGate from '../components/RoleGate'
 import { DEFAULT_INVESTOR_ID } from '../lib/config'
 import { resolveDeadlineDocTarget } from '../lib/deadlines'
-
-const STAGES = [
-  "Primera reunión","NDA","Entrega de información","Generación de propuesta",
-  "Presentación de propuesta","Ajustes técnicos","LOI",
-  "Due diligence fiscal/financiero/riesgos","Revisión de contratos",
-  "Cronograma de inversión","Firma de contratos"
-]
+import { DOCUMENT_SECTIONS_ORDER, DEFAULT_DOC_CATEGORY, DASHBOARD_DOC_CATEGORIES } from '../constants/documents'
+import { PIPELINE_STAGES, FINAL_PIPELINE_STAGE } from '../constants/pipeline'
 
 const PORTFOLIO_OPTIONS = [
   { value: 'solarFarms', label: 'Granjas Solares' },
@@ -29,19 +24,6 @@ const PROJECT_NUMBER_FIELDS = [
   { key: 'energy_mwh', label: 'Energía anual (MWh)' },
   { key: 'co2_tons', label: 'CO₂ evitado (t/año)' }
 ]
-
-const DOC_CATEGORIES = [
-  'NDA',
-  'Propuestas',
-  'Modelos financieros',
-  'Contratos',
-  'LOIs',
-  'Sustento fiscal',
-  'Mitigación de riesgos',
-  'Procesos'
-]
-
-const DASHBOARD_DOC_CATEGORIES = ['NDA', 'Propuestas', 'Contratos']
 
 const createEmptyProject = () => ({
   id: '',
@@ -155,7 +137,7 @@ export default function Admin({ user }){
 
   const [docSlugInput, setDocSlugInput] = useState(DEFAULT_INVESTOR_ID)
   const [docSlug, setDocSlug] = useState(DEFAULT_INVESTOR_ID)
-  const [docCategory, setDocCategory] = useState(DOC_CATEGORIES[0])
+  const [docCategory, setDocCategory] = useState(DEFAULT_DOC_CATEGORY)
   const [docList, setDocList] = useState([])
   const [docsLoading, setDocsLoading] = useState(false)
   const [docsError, setDocsError] = useState(null)
@@ -170,7 +152,7 @@ useEffect(() => {
   window.sessionStorage.removeItem('adminDocsRedirect');
   try {
     const data = JSON.parse(raw);
-    const category = DOC_CATEGORIES.includes(data?.category) ? data.category : DEFAULT_DOC_CATEGORY;
+    const category = DOCUMENT_SECTIONS_ORDER.includes(data?.category) ? data.category : DEFAULT_DOC_CATEGORY;
     const slug = normalizeSlug(data?.slug) || DEFAULT_INVESTOR_ID;
 
     setDocCategory(category);
@@ -235,7 +217,7 @@ const [activityRefreshKey, setActivityRefreshKey] = useState(0);
     return ''
   }, [])
 
-  const finalStageLabel = STAGES[STAGES.length - 1] || ''
+  const finalStageLabel = FINAL_PIPELINE_STAGE
   const numberFormatter = React.useMemo(() => new Intl.NumberFormat('es-MX'), [])
   const percentFormatter = React.useMemo(
     () => new Intl.NumberFormat('es-MX', { maximumFractionDigits: 1 }),
@@ -676,8 +658,8 @@ const [activityRefreshKey, setActivityRefreshKey] = useState(0);
 
   const pipelineSummary = React.useMemo(() => {
     const total = investorList.length
-    const normalizedStages = STAGES.map(stage => stage.toLowerCase())
-    const stageCounts = STAGES.map(stage => {
+    const normalizedStages = PIPELINE_STAGES.map(stage => stage.toLowerCase())
+    const stageCounts = PIPELINE_STAGES.map(stage => {
       const normalizedStage = stage.toLowerCase()
       const count = investorList.filter(item => (item.status || '').trim().toLowerCase() === normalizedStage).length
       const percent = total ? (count / total) * 100 : 0
@@ -829,7 +811,7 @@ const [activityRefreshKey, setActivityRefreshKey] = useState(0);
   }
 
   const navigateToDocsSection = (category, slug, target = 'upload') => {
-    const normalizedCategory = DOC_CATEGORIES.includes(category) ? category : DOC_CATEGORIES[0]
+    const normalizedCategory = DOCUMENT_SECTIONS_ORDER.includes(category) ? category : DEFAULT_DOC_CATEGORY
     const normalizedSlug = normalizeSlug(slug) || DEFAULT_INVESTOR_ID
     setDocsNotice(null)
     setDocsError(null)
@@ -1346,7 +1328,7 @@ const [activityRefreshKey, setActivityRefreshKey] = useState(0);
               <input className="input" placeholder="Nombre de la empresa" value={inv.companyName} onChange={e => setInv({ ...inv, companyName: e.target.value })} required />
               <input className="input" placeholder="Slug deseado (opcional)" value={inv.slug} onChange={e => setInv({ ...inv, slug: e.target.value })} />
               <select className="select" value={inv.status} onChange={e => setInv({ ...inv, status: e.target.value })}>
-                {STAGES.map(s => <option key={s}>{s}</option>)}
+                {PIPELINE_STAGES.map(s => <option key={s}>{s}</option>)}
               </select>
             </div>
             <div style={{marginTop:8}}>
@@ -1493,7 +1475,7 @@ const [activityRefreshKey, setActivityRefreshKey] = useState(0);
                 value={payload.status}
                 onChange={e => setPayload({ ...payload, status: e.target.value })}
               >
-                {STAGES.map(s => <option key={s}>{s}</option>)}
+                {PIPELINE_STAGES.map(s => <option key={s}>{s}</option>)}
               </select>
             </div>
 
@@ -1666,7 +1648,7 @@ const [activityRefreshKey, setActivityRefreshKey] = useState(0);
                 value={docCategory}
                 onChange={e => { setDocCategory(e.target.value); setDocsNotice(null); setDocsError(null) }}
               >
-                {DOC_CATEGORIES.map(cat => (
+                {DOCUMENT_SECTIONS_ORDER.map(cat => (
                   <option key={cat} value={cat}>{cat}</option>
                 ))}
               </select>

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -3,13 +3,7 @@ import { api } from '../lib/api'
 import ProgressBar from '../components/ProgressBar'
 import KPIs from '../components/KPIs'
 import { useInvestorProfile } from '../lib/investor'
-
-const STAGES = [
-  "Primera reunión","NDA","Entrega de información","Generación de propuesta",
-  "Presentación de propuesta","Ajustes técnicos","LOI",
-  "Due diligence fiscal/financiero/riesgos","Revisión de contratos",
-  "Cronograma de inversión","Firma de contratos"
-]
+import { PIPELINE_STAGES } from '../constants/pipeline'
 
 export default function Dashboard(){
   const [investor, setInvestor] = useState(null)
@@ -36,8 +30,8 @@ export default function Dashboard(){
 
   const metrics = investor?.metrics || {}
   const stage = investor?.status ?? ''
-  const stageIndex = stage ? STAGES.findIndex(s => s === stage) : -1
-  const nextSteps = stageIndex >= 0 ? STAGES.slice(stageIndex + 1) : []
+  const stageIndex = stage ? PIPELINE_STAGES.findIndex(s => s === stage) : -1
+  const nextSteps = stageIndex >= 0 ? PIPELINE_STAGES.slice(stageIndex + 1) : []
   const deadlines = investor?.deadlines || {}
   const stageLabel = stage || '—'
 
@@ -54,7 +48,7 @@ export default function Dashboard(){
 
       <div className="card">
         <div className="h2">Avance</div>
-        <ProgressBar stages={STAGES} current={stage} />
+        <ProgressBar stages={PIPELINE_STAGES} current={stage} />
         <div style={{marginTop:10, fontSize:14}}>
           <strong>Etapa actual:</strong> {stageLabel}
         </div>

--- a/src/pages/Documents.jsx
+++ b/src/pages/Documents.jsx
@@ -1,33 +1,83 @@
-import React, { useEffect, useState } from 'react'
+import React, { useCallback, useEffect, useState } from 'react'
 import { api } from '../lib/api'
 import { useInvestorProfile } from '../lib/investor'
+import { DOCUMENT_SECTIONS_ORDER } from '../constants/documents'
 
 export default function Documents(){
-  const [docs, setDocs] = useState([])
+  const [docsByCategory, setDocsByCategory] = useState({})
   const [loading, setLoading] = useState(false)
-  const [category, setCategory] = useState('NDA')
   const [error, setError] = useState(null)
+  const [uploadingCategory, setUploadingCategory] = useState(null)
+  const [hasLoaded, setHasLoaded] = useState(false)
   const { investorId } = useInvestorProfile()
 
-  async function load(){
-    try{
-      setLoading(true); setError(null)
-      const res = await api.listDocs({ category, slug: investorId })
-      setDocs(res.files || [])
-    }catch(e){ setError(e.message) }
-    finally{ setLoading(false) }
-  }
-  useEffect(() => { load() }, [category, investorId])
+  const fetchDocs = useCallback(async (category) => {
+    const res = await api.listDocs({ category, slug: investorId })
+    const files = Array.isArray(res?.files) ? res.files : []
+    return files
+  }, [investorId])
 
-  async function onUpload(e){
+  const refreshCategory = useCallback(async (category) => {
+    const files = await fetchDocs(category)
+    setDocsByCategory(prev => ({ ...prev, [category]: files }))
+    return files
+  }, [fetchDocs])
+
+  const loadAll = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    try{
+      const results = await Promise.allSettled(
+        DOCUMENT_SECTIONS_ORDER.map(async (category) => {
+          const files = await fetchDocs(category)
+          return [category, files]
+        })
+      )
+      const next = {}
+      const errors = []
+      results.forEach((result, index) => {
+        const fallbackCategory = DOCUMENT_SECTIONS_ORDER[index]
+        if (result.status === 'fulfilled'){
+          const [category, files] = result.value
+          next[category] = files
+        }else{
+          const message = result.reason?.message || 'Error desconocido'
+          next[fallbackCategory] = []
+          errors.push(`${fallbackCategory}: ${message}`)
+        }
+      })
+      setDocsByCategory(next)
+      if (errors.length){
+        const suffix = errors.length === 1 ? '' : 's'
+        setError(`No se pudieron cargar ${errors.length} categoría${suffix}.`)
+      }
+    }catch(err){
+      setDocsByCategory({})
+      setError(err.message)
+    }finally{
+      setLoading(false)
+      setHasLoaded(true)
+    }
+  }, [fetchDocs])
+
+  useEffect(() => {
+    loadAll()
+  }, [loadAll])
+
+  const handleUpload = useCallback((category) => (e) => {
     e.preventDefault()
-    const file = e.target.file.files[0]
+    setError(null)
+    const form = e.target
+    const fileInput = form.file
+    const file = fileInput && fileInput.files ? fileInput.files[0] : null
     if (!file) return
     const reader = new FileReader()
+    setUploadingCategory(category)
     reader.onload = async () => {
       try{
-        setLoading(true); setError(null)
-        const contentBase64 = reader.result.split(',')[1]
+        const result = typeof reader.result === 'string' ? reader.result : ''
+        const contentBase64 = result.includes(',') ? result.split(',')[1] : ''
+        if (!contentBase64) throw new Error('No se pudo leer el archivo')
         await api.uploadDoc({
           path: `${category}`,
           filename: file.name,
@@ -35,58 +85,86 @@ export default function Documents(){
           contentBase64,
           slug: investorId
         })
-        await load()
+        form.reset()
+        await refreshCategory(category)
         alert('Archivo subido')
-      }catch(err){ setError(err.message) }
-      finally{ setLoading(false) }
+      }catch(err){
+        setError(err.message)
+      }finally{
+        setUploadingCategory(null)
+      }
+    }
+    reader.onerror = () => {
+      setUploadingCategory(null)
+      setError('No se pudo leer el archivo')
     }
     reader.readAsDataURL(file)
-  }
+  }, [investorId, refreshCategory])
 
   return (
     <div className="container">
-      <div className="row" style={{justifyContent:'space-between'}}>
+      <div className="row" style={{ justifyContent: 'space-between', alignItems: 'center' }}>
         <div className="h1">Biblioteca de documentos</div>
-        <div className="form-row" style={{maxWidth:420}}>
-          <select className="select" value={category} onChange={e => setCategory(e.target.value)}>
-            <option>NDA</option>
-            <option>Propuestas</option>
-            <option>Modelos financieros</option>
-            <option>Contratos</option>
-            <option>LOIs</option>
-            <option>Sustento fiscal</option>
-            <option>Mitigación de riesgos</option>
-            <option>Procesos</option>
-          </select>
-          <button className="btn" onClick={load}>Actualizar</button>
-        </div>
+        <button className="btn" onClick={() => loadAll()} disabled={loading}>
+          {loading ? 'Actualizando…' : 'Actualizar'}
+        </button>
       </div>
 
-      <div className="card">
-        <form onSubmit={onUpload} className="form-row">
-          <input name="file" type="file" className="input" />
-          <button className="btn" type="submit">Subir</button>
-          <span className="notice">Los archivos se guardan en GitHub y se exponen públicamente.</span>
-        </form>
+      <div className="card" style={{ marginTop: 12 }}>
+        <span className="notice">Los archivos se guardan en GitHub y se exponen públicamente.</span>
       </div>
 
-      {error && <div className="notice" style={{marginTop:12}}>{error}</div>}
-      {loading && <p>Cargando…</p>}
-      <table className="table" style={{marginTop:12}}>
-        <thead><tr><th>Archivo</th><th>Tamaño</th><th></th></tr></thead>
-        <tbody>
-          {docs.map(d => (
-            <tr key={d.path}>
-              <td>{d.name}</td>
-              <td>{(d.size/1024).toFixed(1)} KB</td>
-              <td>
-                <a className="btn secondary" href={api.downloadDocPath(d.path)}>Descargar</a>
-              </td>
-            </tr>
-          ))}
-          {docs.length === 0 && !loading && <tr><td colSpan="3">No hay documentos aún.</td></tr>}
-        </tbody>
-      </table>
+      {error && <div className="notice" style={{ marginTop: 12 }}>{error}</div>}
+
+      <div style={{ marginTop: 12, display: 'grid', gap: 24 }}>
+        {DOCUMENT_SECTIONS_ORDER.map((category) => {
+          const docs = docsByCategory[category] || []
+          const isUploading = uploadingCategory === category
+          return (
+            <section key={category}>
+              <h2 className="h2" style={{ marginBottom: 8 }}>{category}</h2>
+              <div className="card" style={{ padding: 0 }}>
+                <form onSubmit={handleUpload(category)} className="form-row" style={{ padding: 16, borderBottom: '1px solid #f0f0f0' }}>
+                  <input name="file" type="file" className="input" disabled={isUploading} />
+                  <button className="btn" type="submit" disabled={isUploading}>
+                    {isUploading ? 'Subiendo…' : 'Subir'}
+                  </button>
+                </form>
+                <table className="table" style={{ margin: 0 }}>
+                  <thead>
+                    <tr>
+                      <th>Archivo</th>
+                      <th>Tamaño</th>
+                      <th></th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {docs.map((d) => (
+                      <tr key={d.path}>
+                        <td>{d.name}</td>
+                        <td>{(d.size / 1024).toFixed(1)} KB</td>
+                        <td>
+                          <a className="btn secondary" href={api.downloadDocPath(d.path)}>Descargar</a>
+                        </td>
+                      </tr>
+                    ))}
+                    {docs.length === 0 && hasLoaded && !loading && (
+                      <tr>
+                        <td colSpan="3">No hay documentos aún.</td>
+                      </tr>
+                    )}
+                    {docs.length === 0 && loading && (
+                      <tr>
+                        <td colSpan="3">Cargando…</td>
+                      </tr>
+                    )}
+                  </tbody>
+                </table>
+              </div>
+            </section>
+          )
+        })}
+      </div>
     </div>
   )
 }

--- a/src/pages/Updates.jsx
+++ b/src/pages/Updates.jsx
@@ -4,15 +4,8 @@ import { api } from '../lib/api'
 import { DEFAULT_INVESTOR_ID } from '../lib/config'
 import { resolveDeadlineDocTarget, DEADLINE_DOC_CATEGORIES } from '../lib/deadlines'
 import { useInvestorProfile } from '../lib/investor'
-
-const STAGES = [
-  "Primera reunión","NDA","Entrega de información","Generación de propuesta",
-  "Presentación de propuesta","Ajustes técnicos","LOI",
-  "Due diligence fiscal/financiero/riesgos","Revisión de contratos",
-  "Cronograma de inversión","Firma de contratos"
-]
-
-const DASHBOARD_DOC_CATEGORIES = ['NDA', 'Propuestas', 'Contratos']
+import { PIPELINE_STAGES, FINAL_PIPELINE_STAGE } from '../constants/pipeline'
+import { DASHBOARD_DOC_CATEGORIES } from '../constants/documents'
 const DOC_REDIRECT_CATEGORIES = Array.from(new Set([
   ...DASHBOARD_DOC_CATEGORIES,
   ...DEADLINE_DOC_CATEGORIES
@@ -50,7 +43,7 @@ export default function Updates(){
       .catch(() => setItems([]))
   }, [])
 
-  const finalStageLabel = STAGES[STAGES.length - 1] || ''
+  const finalStageLabel = FINAL_PIPELINE_STAGE
   const numberFormatter = useMemo(() => new Intl.NumberFormat('es-MX'), [])
   const percentFormatter = useMemo(
     () => new Intl.NumberFormat('es-MX', { maximumFractionDigits: 1 }),
@@ -241,8 +234,8 @@ export default function Updates(){
 
   const pipelineSummary = useMemo(() => {
     const total = investorList.length
-    const normalizedStages = STAGES.map(stage => stage.toLowerCase())
-    const stageCounts = STAGES.map(stage => {
+    const normalizedStages = PIPELINE_STAGES.map(stage => stage.toLowerCase())
+    const stageCounts = PIPELINE_STAGES.map(stage => {
       const normalizedStage = stage.toLowerCase()
       const count = investorList.filter(item => (item.status || '').trim().toLowerCase() === normalizedStage).length
       const percent = total ? (count / total) * 100 : 0


### PR DESCRIPTION
## Summary
- update the pipeline stage ordering to place "Revisión de contratos" before "Due diligence fiscal/financiero/riesgos" and centralize usage of the shared constant across public and admin dashboards
- rework the documents page into a continuous sectioned list backed by shared document category constants that align with the pipeline

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d5774fdb58832db64dd9a22b8715b2