### PR TITLE
Normaliza captura de deadlines de Firma en Admin

### DIFF
--- a/src/utils/deadlines.js
+++ b/src/utils/deadlines.js
@@ -1,0 +1,22 @@
+export function normalizeDeadlineKey(inputKey) {
+  const k = String(inputKey || '').trim().toLowerCase()
+  if (!k) return ''
+
+  if (k === 'firma' || k.startsWith('firma ')) return 'Firma'
+  if (k.includes('firma') && k.includes('contrato')) return 'Firma'
+
+  return String(inputKey || '').trim()
+}
+
+export function isValidISODate(d) {
+  if (typeof d !== 'string') return false
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(d)) return false
+  const dt = new Date(d)
+  const [y, m, day] = d.split('-').map(n => parseInt(n, 10))
+  return (
+    !Number.isNaN(+dt) &&
+    dt.getUTCFullYear() === y &&
+    dt.getUTCMonth() + 1 === m &&
+    dt.getUTCDate() === day
+  )
+}


### PR DESCRIPTION
## Summary
- add deadline utilities to normalize deadline keys and validate ISO dates
- update admin deadline serialization to reuse the normalization helper and block invalid dates
- normalize keys on blur in admin forms, merging duplicate “Firma” deadlines when detected

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d6cf35dfac832dba23299e3279271f