### PR TITLE
feat: validate investor deadlines before persisting

### DIFF
--- a/netlify/functions/create-investor.mjs
+++ b/netlify/functions/create-investor.mjs
@@ -1,6 +1,8 @@
 import { json } from './_lib/utils.mjs'
 import { repoEnv, getFile, putFile } from './_lib/github.mjs'
 import { decodeIndexContent, buildIndexPayload, normalizeName } from './_lib/investor-index.mjs'
+import { getStageOrder } from '../lib/stages.mjs'
+import { validateDeadlines } from '../lib/validators.mjs'
 
 const normalizeSlug = (value) => {
   const base = (value || '').toString().trim()
@@ -105,6 +107,14 @@ export async function handler(event){
     delete extras.deadlines
     delete extras.metrics
     delete extras.ui
+
+    if (deadlines && Object.keys(deadlines).length){
+      const order = getStageOrder()
+      const validation = validateDeadlines(deadlines, order)
+      if (!validation.ok){
+        return json(400, { ok: false, error: validation.error, ...validation.details })
+      }
+    }
 
     const nowISO = new Date().toISOString()
     const investor = {

--- a/netlify/functions/update-investor.mjs
+++ b/netlify/functions/update-investor.mjs
@@ -1,0 +1,89 @@
+import { json } from './_lib/utils.mjs'
+import { repoEnv, getFile, putFile } from './_lib/github.mjs'
+import { getStageOrder } from '../lib/stages.mjs'
+import { validateDeadlines } from '../lib/validators.mjs'
+
+const isGitHubNotFound = (error) => {
+  const message = String(error && error.message ? error.message : error)
+  return message.includes('GitHub 404')
+}
+
+const decodeFileContent = (file) => {
+  if (!file) return ''
+  const encoding = file.encoding || 'base64'
+  return Buffer.from(file.content || '', encoding).toString('utf-8')
+}
+
+export async function handler(event){
+  try {
+    if (event.httpMethod && event.httpMethod !== 'POST'){
+      return json(405, { ok: false, error: 'Method not allowed' })
+    }
+
+    const body = JSON.parse(event.body || '{}')
+    const slug = typeof body.slug === 'string' ? body.slug.trim() : ''
+    if (!slug){
+      return json(400, { ok: false, error: "Missing required field 'slug'" })
+    }
+
+    const repo = repoEnv('CONTENT_REPO', '')
+    const branch = process.env.CONTENT_BRANCH || 'main'
+    if (!repo || !process.env.GITHUB_TOKEN){
+      return json(500, { ok: false, error: 'Missing GitHub configuration' })
+    }
+
+    const path = `data/investors/${slug}.json`
+
+    let investorFile
+    try {
+      investorFile = await getFile(repo, path, branch)
+    } catch (error) {
+      if (isGitHubNotFound(error)){
+        return json(404, { ok: false, error: 'Investor not found' })
+      }
+      throw error
+    }
+
+    const current = JSON.parse(decodeFileContent(investorFile) || '{}')
+    const existingDeadlines = current && typeof current.deadlines === 'object' ? current.deadlines : {}
+
+    const incomingDeadlines = body.deadlines && typeof body.deadlines === 'object' ? body.deadlines : {}
+    const mergedDeadlines = { ...existingDeadlines }
+    for (const [stage, value] of Object.entries(incomingDeadlines)){
+      if (value === null || value === undefined || value === ''){
+        delete mergedDeadlines[stage]
+      } else {
+        mergedDeadlines[stage] = value
+      }
+    }
+
+    if (Object.keys(mergedDeadlines).length){
+      const order = getStageOrder()
+      const validation = validateDeadlines(mergedDeadlines, order)
+      if (!validation.ok){
+        return json(400, { ok: false, error: validation.error, ...validation.details })
+      }
+    }
+
+    const updatedInvestor = {
+      ...current,
+      deadlines: mergedDeadlines,
+      updatedAt: new Date().toISOString()
+    }
+
+    const contentBase64 = Buffer.from(JSON.stringify(updatedInvestor, null, 2)).toString('base64')
+    await putFile(
+      repo,
+      path,
+      contentBase64,
+      `feat(deadlines): update ${slug}`,
+      investorFile?.sha,
+      branch
+    )
+
+    return json(200, { ok: true })
+  } catch (error) {
+    const message = String(error && error.message ? error.message : error)
+    return json(500, { ok: false, error: message })
+  }
+}

--- a/netlify/lib/stages.mjs
+++ b/netlify/lib/stages.mjs
@@ -1,0 +1,17 @@
+// /netlify/lib/stages.mjs
+// Orden actualizado: Revisión de contratos va ANTES que Due Diligence.
+export function getStageOrder() {
+  return [
+    "Primera reunión",
+    "NDA",
+    "Entrega de información",
+    "Generación de propuesta",
+    "Presentación de propuesta",
+    "Ajustes técnicos",
+    "LOI",
+    "Revisión de contratos",
+    "Due Diligence",            // <= va después de "Revisión de contratos"
+    "Cronograma de inversión",
+    "Firma"
+  ];
+}

--- a/netlify/lib/validators.mjs
+++ b/netlify/lib/validators.mjs
@@ -1,0 +1,60 @@
+// /netlify/lib/validators.mjs
+export const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+export function isValidISODate(s) {
+  if (typeof s !== "string" || !ISO_DATE_RE.test(s)) return false;
+  const d = new Date(s);
+  return !Number.isNaN(d.getTime()) && d.toISOString().slice(0, 10) === s;
+}
+
+/**
+ * Valida:
+ * 1) Formato de cada fecha (YYYY-MM-DD)
+ * 2) Orden cronológico no decreciente según getStageOrder()
+ * Devuelve { ok: true } o { ok: false, error, details }
+ */
+export function validateDeadlines(deadlines, stageOrder) {
+  const dl = deadlines || {};
+  const order = Array.isArray(stageOrder) ? stageOrder : [];
+  const allowedStages = new Set(order);
+
+  // 1) formato y nombres válidos
+  for (const [k, v] of Object.entries(dl)) {
+    if (!allowedStages.has(k)) {
+      return {
+        ok: false,
+        error: "DEADLINE_STAGE_INVALID",
+        details: { field: k, allowed: order }
+      };
+    }
+    if (!isValidISODate(v)) {
+      return {
+        ok: false,
+        error: "DEADLINE_FORMAT_INVALID",
+        details: { field: k, value: v, expected: "YYYY-MM-DD" }
+      };
+    }
+  }
+
+  // 2) orden (lexicográfico funciona con ISO: "2025-09-28" < "2025-10-01")
+  const presentStages = order.filter((s) => dl[s]);
+  for (let i = 0; i < presentStages.length - 1; i++) {
+    const a = presentStages[i];
+    const b = presentStages[i + 1];
+    if (dl[a] > dl[b]) {
+      return {
+        ok: false,
+        error: "DEADLINE_ORDER_INVALID",
+        details: {
+          a,
+          b,
+          aDate: dl[a],
+          bDate: dl[b],
+          rule: `"${a}" <= "${b}"`,
+          message: `La fecha de "${a}" (${dl[a]}) no puede ser posterior a "${b}" (${dl[b]}).`
+        }
+      };
+    }
+  }
+  return { ok: true };
+}


### PR DESCRIPTION
## Summary
- add a shared stage order definition consumable by functions
- add utilities to validate ISO-formatted deadlines and enforce stage order
- validate deadlines during investor creation and updates, rejecting invalid payloads

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d98664740c832db1d825381c56acc7