### PR TITLE
Implement deadline autocomplete and live validation

### DIFF
--- a/src/components/deadlines/DeadlinesForm.tsx
+++ b/src/components/deadlines/DeadlinesForm.tsx
@@ -1,0 +1,131 @@
+import { useEffect, useMemo, useState } from 'react'
+import { DeadlinesRow } from './DeadlinesRow'
+import { normalize, suggestNextStage, validateRows } from '@/lib/deadlineValidators'
+import { STAGES } from '@/lib/stages'
+
+type Row = { stage?: string; date?: string }
+
+type Props = {
+  initial?: Row[]
+  onChange?: (rows: Row[]) => void
+  onSubmit?: (rows: Row[]) => void | Promise<void>
+  showSubmitButton?: boolean
+  submitLabel?: string
+  submitting?: boolean
+  onValidationChange?: (result: ReturnType<typeof validateRows>) => void
+}
+
+export function DeadlinesForm({
+  initial = [],
+  onChange,
+  onSubmit,
+  showSubmitButton = true,
+  submitLabel = 'Guardar',
+  submitting = false,
+  onValidationChange,
+}: Props) {
+  const [rows, setRows] = useState<Row[]>(initial.length ? initial : [{ stage: '', date: '' }])
+
+  useEffect(() => {
+    setRows(initial.length ? initial : [{ stage: '', date: '' }])
+  }, [initial])
+
+  const canonicalByNorm = useMemo(() => {
+    const map: Record<string, string> = {}
+    STAGES.forEach(stage => {
+      map[normalize(stage)] = stage
+    })
+    return map
+  }, [])
+
+  const validation = useMemo(() => validateRows(rows), [rows])
+
+  useEffect(() => {
+    onValidationChange?.(validation)
+  }, [validation, onValidationChange])
+
+  const usedCanonical = useMemo(() => {
+    const used = new Set<string>()
+    rows.forEach(r => {
+      const canonical = canonicalByNorm[normalize(r.stage || '')]
+      if (canonical) used.add(canonical)
+    })
+    return used
+  }, [rows, canonicalByNorm])
+
+  const availableOptions = useMemo(() => {
+    return rows.map(r => {
+      const current = canonicalByNorm[normalize(r.stage || '')]
+      return STAGES.filter(stage => stage === current || !usedCanonical.has(stage))
+    })
+  }, [rows, canonicalByNorm, usedCanonical])
+
+  function updateRow(i: number, next: Row) {
+    setRows(prev => {
+      const copy = prev.slice()
+      copy[i] = next
+      onChange?.(copy)
+      return copy
+    })
+  }
+
+  function addRow() {
+    setRows(prev => {
+      const suggestion = suggestNextStage(prev) || ''
+      const next = [...prev, { stage: suggestion, date: '' }]
+      onChange?.(next)
+      return next
+    })
+  }
+
+  function removeRow(index: number) {
+    setRows(prev => {
+      if (prev.length <= 1) {
+        const fallback = [{ stage: '', date: '' }]
+        onChange?.(fallback)
+        return fallback
+      }
+      const next = prev.filter((_, idx) => idx !== index)
+      onChange?.(next)
+      return next
+    })
+  }
+
+  function handleSubmit() {
+    if (!validation.ok || submitting) return
+    onSubmit?.(rows)
+  }
+
+  const canSave = validation.ok && !submitting
+
+  return (
+    <div style={{ display: 'grid', gap: 8 }}>
+      {rows.map((r, i) => (
+        <DeadlinesRow
+          key={i}
+          value={r}
+          onChange={v => updateRow(i, v)}
+          stageOptions={availableOptions[i]}
+          onRemove={rows.length > 1 ? () => removeRow(i) : undefined}
+          canRemove={rows.length > 1}
+        />
+      ))}
+
+      {!validation.ok && validation?.message && (
+        <div style={{ color: '#b42318', fontSize: 12 }}>{validation.message}</div>
+      )}
+
+      <div className="form-row" style={{ gap: 8 }}>
+        <button type="button" className="btn secondary" onClick={addRow}>
+          Agregar deadline
+        </button>
+
+        {showSubmitButton && (
+          <button type="button" className="btn" disabled={!canSave} onClick={handleSubmit}>
+            {submitting ? 'Guardando…' : submitLabel}
+          </button>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/components/deadlines/DeadlinesRow.tsx
+++ b/src/components/deadlines/DeadlinesRow.tsx
@@ -1,0 +1,76 @@
+import { type CSSProperties, useId } from 'react'
+import { STAGES } from '@/lib/stages'
+
+type Props = {
+  value: { stage?: string; date?: string }
+  onChange: (v: { stage?: string; date?: string }) => void
+  stageOptions?: string[]
+  error?: string | null
+  onRemove?: () => void
+  canRemove?: boolean
+}
+
+const fieldStyle: CSSProperties = {
+  display: 'flex',
+  flexDirection: 'column',
+  flex: 1,
+  minWidth: 200,
+}
+
+const labelStyle: CSSProperties = {
+  fontSize: 12,
+  fontWeight: 700,
+  color: 'var(--muted)',
+  marginBottom: 4,
+}
+
+export function DeadlinesRow({ value, onChange, stageOptions, error, onRemove, canRemove }: Props) {
+  const { stage = '', date = '' } = value || {}
+  const options = stageOptions && stageOptions.length ? stageOptions : STAGES
+  const listId = useId()
+
+  return (
+    <div style={{ width: '100%' }}>
+      <div className="form-row" style={{ alignItems: 'flex-end' }}>
+        <div style={fieldStyle}>
+          <label htmlFor={`${listId}-stage`} style={labelStyle}>
+            Etapa
+          </label>
+          <input
+            id={`${listId}-stage`}
+            list={listId}
+            className="input"
+            value={stage}
+            onChange={e => onChange({ ...value, stage: e.target.value })}
+            placeholder="Empieza a escribir…"
+          />
+          <datalist id={listId}>
+            {options.map(s => (
+              <option key={s} value={s} />
+            ))}
+          </datalist>
+        </div>
+        <div style={fieldStyle}>
+          <label htmlFor={`${listId}-date`} style={labelStyle}>
+            Fecha
+          </label>
+          <input
+            id={`${listId}-date`}
+            type="date"
+            className="input"
+            value={date}
+            onChange={e => onChange({ ...value, date: e.target.value })}
+          />
+        </div>
+        {canRemove && onRemove && (
+          <div style={{ display: 'flex', alignItems: 'flex-end' }}>
+            <button type="button" className="btn secondary" onClick={onRemove}>
+              Eliminar
+            </button>
+          </div>
+        )}
+      </div>
+      {error && <div style={{ color: '#b42318', fontSize: 12, marginTop: 4 }}>{error}</div>}
+    </div>
+  )
+}

--- a/src/lib/deadlineValidators.ts
+++ b/src/lib/deadlineValidators.ts
@@ -1,0 +1,94 @@
+import { STAGES } from './stages'
+
+const ISO_RE = /^\d{4}-\d{2}-\d{2}$/
+
+export function isValidISODate(s: string) {
+  if (!ISO_RE.test(s)) return false
+  const d = new Date(s)
+  return !Number.isNaN(d.getTime()) && d.toISOString().slice(0, 10) === s
+}
+
+export function normalize(s: string) {
+  return (s || '')
+    .normalize('NFD')
+    .replace(/\p{Diacritic}/gu, '')
+    .trim()
+    .toLowerCase()
+}
+
+/**
+ * rows: Array<{ stage: string; date: string }>
+ * Valida:
+ *  - formato de fecha
+ *  - etapas duplicadas
+ *  - orden cronológico según STAGES (solo compara etapas presentes)
+ */
+export function validateRows(rows: Array<{ stage?: string; date?: string }>) {
+  // normaliza y arma mapa stage->date con la forma canónica de etapa
+  const stageByNorm: Record<string, string> = {}
+  STAGES.forEach(s => (stageByNorm[normalize(s)] = s))
+
+  const usedStages = new Set<string>()
+  const deadlines: Record<string, string> = {}
+
+  for (const r of rows) {
+    const stageInput = r.stage?.trim() || ''
+    const date = r.date?.trim() || ''
+
+    if (!stageInput && !date) continue // fila vacía
+
+    // mapear "firma" -> "Firma", ignorando acentos/caso/espacios
+    const canonical = stageByNorm[normalize(stageInput)]
+    if (!canonical) {
+      return { ok: false, message: `Etapa inválida: "${stageInput}". Selecciona una de la lista.` }
+    }
+
+    if (!date) {
+      return { ok: false, message: `Falta la fecha para "${canonical}".` }
+    }
+
+    if (!isValidISODate(date)) {
+      return { ok: false, message: `Fecha inválida en "${canonical}". Usa formato YYYY-MM-DD.` }
+    }
+
+    if (usedStages.has(canonical)) {
+      return { ok: false, message: `La etapa "${canonical}" está repetida.` }
+    }
+    usedStages.add(canonical)
+    deadlines[canonical] = date
+  }
+
+  // orden no-decreciente según STAGES
+  const present = STAGES.filter(s => deadlines[s])
+  for (let i = 0; i < present.length - 1; i++) {
+    const a = present[i], b = present[i + 1]
+    if (deadlines[a] > deadlines[b]) {
+      return {
+        ok: false,
+        message: `La fecha de "${a}" (${deadlines[a]}) no puede ser posterior a "${b}" (${deadlines[b]}).`
+      }
+    }
+  }
+
+  return { ok: true, deadlines, canonicalStages: Array.from(usedStages) }
+}
+
+/** devuelve la siguiente etapa sugerida que aún no está en rows */
+export function suggestNextStage(rows: Array<{ stage?: string }>) {
+  const current = new Set(
+    rows
+      .map(r => r.stage || '')
+      .map(s => stageByCanonicalOrNull(s))
+      .filter(Boolean) as string[]
+  )
+  for (const s of STAGES) {
+    if (!current.has(s)) return s
+  }
+  return '' // no hay sugerencia
+}
+
+function stageByCanonicalOrNull(s: string) {
+  const map: Record<string, string> = {}
+  STAGES.forEach(x => (map[normalize(x)] = x))
+  return map[normalize(s)] || ''
+}

--- a/src/lib/stages.ts
+++ b/src/lib/stages.ts
@@ -1,0 +1,13 @@
+export const STAGES = [
+  'Primera reunión',
+  'NDA',
+  'Entrega de información',
+  'Generación de propuesta',
+  'Presentación de propuesta',
+  'Ajustes técnicos',
+  'LOI',
+  'Revisión de contratos',
+  'Due Diligence',
+  'Cronograma de inversión',
+  'Firma',
+];


### PR DESCRIPTION
## Summary
- add a canonical pipeline stage list and deadline validation helpers
- build reusable deadlines form components with autocomplete, duplicate prevention, and per-row removal
- integrate the deadlines form into investor creation and update flows with live validation, async saving, and slug checks

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d98a18fc30832d8e2031a86fe359f3