### PR TITLE
feat(deadlines): add autocomplete and live validation

### DIFF
--- a/src/components/deadlines/DeadlinesForm.tsx
+++ b/src/components/deadlines/DeadlinesForm.tsx
@@ -1,0 +1,105 @@
+import { useEffect, useMemo, useState } from "react";
+import { DeadlinesRow } from "./DeadlinesRow";
+import { suggestNextStage, validateRows, normalize } from "@/lib/deadlineValidators";
+import { STAGES } from "@/lib/stages";
+
+type Row = { stage?: string; date?: string };
+
+type Props = {
+  initial?: Row[];
+  onChange?: (rows: Row[]) => void;
+  onSubmit?: (rows: Row[]) => void | Promise<void>;
+  saving?: boolean;
+};
+
+const EMPTY_ROW: Row = { stage: "", date: "" };
+
+export function DeadlinesForm({ initial = [], onChange, onSubmit, saving = false }: Props) {
+  const [rows, setRows] = useState<Row[]>(initial.length ? initial : [EMPTY_ROW]);
+  const serializedInitial = useMemo(() => JSON.stringify(initial || []), [initial]);
+
+  useEffect(() => {
+    const base = initial.length ? initial : [EMPTY_ROW];
+    setRows(base.map(item => ({ ...item })));
+  }, [serializedInitial, initial]);
+
+  const stageByNorm = useMemo(() => {
+    const map: Record<string, string> = {};
+    STAGES.forEach(stage => {
+      map[normalize(stage)] = stage;
+    });
+    return map;
+  }, []);
+
+  const { validation, availableOptions } = useMemo(() => {
+    const validationResult = validateRows(rows);
+
+    const usedCanonical = rows
+      .map(row => stageByNorm[normalize(row.stage || "")])
+      .filter(Boolean) as string[];
+
+    const options = rows.map(row => {
+      const canonical = stageByNorm[normalize(row.stage || "")];
+      const blocked = new Set(usedCanonical);
+      if (canonical) blocked.delete(canonical);
+      return STAGES.filter(stage => !blocked.has(stage));
+    });
+
+    return { validation: validationResult, availableOptions: options };
+  }, [rows, stageByNorm]);
+
+  function updateRow(i: number, next: Row) {
+    const copy = rows.slice();
+    copy[i] = next;
+    setRows(copy);
+    onChange?.(copy);
+  }
+
+  function addRow() {
+    const suggestion = suggestNextStage(rows) || "";
+    const nextRows = [...rows, { stage: suggestion, date: "" }];
+    setRows(nextRows);
+    onChange?.(nextRows);
+  }
+
+  const canSave = validation.ok && !saving;
+
+  return (
+    <div className="space-y-3">
+      {rows.map((r, i) => (
+        <DeadlinesRow
+          key={i}
+          value={r}
+          onChange={v => updateRow(i, v)}
+          stageOptions={availableOptions[i]}
+        />
+      ))}
+
+      {!validation.ok && validation?.message && (
+        <div className="text-red-600 text-sm">{validation.message}</div>
+      )}
+
+      <div className="flex gap-2">
+        <button
+          type="button"
+          className="px-3 py-2 rounded bg-gray-100"
+          onClick={addRow}
+        >
+          Agregar deadline
+        </button>
+
+        <button
+          type="button"
+          className="px-3 py-2 rounded bg-purple-600 text-white disabled:opacity-50"
+          disabled={!canSave}
+          onClick={() => {
+            if (!validation.ok || saving) return;
+            onSubmit?.(rows);
+          }}
+        >
+          {saving ? "Guardando…" : "Guardar"}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/deadlines/DeadlinesRow.tsx
+++ b/src/components/deadlines/DeadlinesRow.tsx
@@ -1,0 +1,47 @@
+import { useId } from "react";
+import { STAGES } from "@/lib/stages";
+
+type Props = {
+  value: { stage?: string; date?: string };
+  onChange: (v: { stage?: string; date?: string }) => void;
+  stageOptions?: string[]; // para ocultar etapas ya usadas
+  error?: string | null;
+};
+
+export function DeadlinesRow({ value, onChange, stageOptions, error }: Props) {
+  const { stage = "", date = "" } = value || {};
+  const options = stageOptions && stageOptions.length ? stageOptions : STAGES;
+  const listId = useId();
+
+  return (
+    <div className="grid grid-cols-2 gap-3">
+      <div>
+        <label className="block text-sm mb-1">Etapa</label>
+        <input
+          list={listId}
+          className="w-full border rounded p-2"
+          value={stage}
+          onChange={e => onChange({ ...value, stage: e.target.value })}
+          placeholder="Empieza a escribir…"
+        />
+        <datalist id={listId}>
+          {options.map(s => (
+            <option key={s} value={s} />
+          ))}
+        </datalist>
+      </div>
+
+      <div>
+        <label className="block text-sm mb-1">Fecha</label>
+        <input
+          type="date"
+          className="w-full border rounded p-2"
+          value={date}
+          onChange={e => onChange({ ...value, date: e.target.value })}
+        />
+      </div>
+
+      {error && <div className="col-span-2 text-red-600 text-sm mt-1">{error}</div>}
+    </div>
+  );
+}

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -48,6 +48,9 @@ export const api = {
   async updateStatus(payload){
     return req('/.netlify/functions/update-status', { method:'POST', body: payload })
   },
+  async updateInvestor(payload){
+    return req('/.netlify/functions/update-investor', { method: 'POST', body: payload })
+  },
   async createInvestor(payload){
     return req('/.netlify/functions/create-investor', { method:'POST', body: payload })
   },

--- a/src/lib/deadlineValidators.ts
+++ b/src/lib/deadlineValidators.ts
@@ -1,0 +1,94 @@
+import { STAGES } from "./stages";
+
+const ISO_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+export function isValidISODate(s: string) {
+  if (!ISO_RE.test(s)) return false;
+  const d = new Date(s);
+  return !Number.isNaN(d.getTime()) && d.toISOString().slice(0, 10) === s;
+}
+
+export function normalize(s: string) {
+  return (s || "")
+    .normalize("NFD")
+    .replace(/\p{Diacritic}/gu, "")
+    .trim()
+    .toLowerCase();
+}
+
+/**
+ * rows: Array<{ stage: string; date: string }>
+ * Valida:
+ *  - formato de fecha
+ *  - etapas duplicadas
+ *  - orden cronológico según STAGES (solo compara etapas presentes)
+ */
+export function validateRows(rows: Array<{ stage?: string; date?: string }>) {
+  // normaliza y arma mapa stage->date con la forma canónica de etapa
+  const stageByNorm: Record<string, string> = {};
+  STAGES.forEach(s => (stageByNorm[normalize(s)] = s));
+
+  const usedStages = new Set<string>();
+  const deadlines: Record<string, string> = {};
+
+  for (const r of rows) {
+    const stageInput = r.stage?.trim() || "";
+    const date = r.date?.trim() || "";
+
+    if (!stageInput && !date) continue; // fila vacía
+
+    // mapear "firma" -> "Firma", ignorando acentos/caso/espacios
+    const canonical = stageByNorm[normalize(stageInput)];
+    if (!canonical) {
+      return { ok: false, message: `Etapa inválida: "${stageInput}". Selecciona una de la lista.` };
+    }
+
+    if (!date) {
+      return { ok: false, message: `Falta la fecha para "${canonical}".` };
+    }
+
+    if (!isValidISODate(date)) {
+      return { ok: false, message: `Fecha inválida en "${canonical}". Usa formato YYYY-MM-DD.` };
+    }
+
+    if (usedStages.has(canonical)) {
+      return { ok: false, message: `La etapa "${canonical}" está repetida.` };
+    }
+    usedStages.add(canonical);
+    deadlines[canonical] = date;
+  }
+
+  // orden no-decreciente según STAGES
+  const present = STAGES.filter(s => deadlines[s]);
+  for (let i = 0; i < present.length - 1; i++) {
+    const a = present[i], b = present[i + 1];
+    if (deadlines[a] > deadlines[b]) {
+      return {
+        ok: false,
+        message: `La fecha de "${a}" (${deadlines[a]}) no puede ser posterior a "${b}" (${deadlines[b]}).`,
+      };
+    }
+  }
+
+  return { ok: true, deadlines, canonicalStages: Array.from(usedStages) };
+}
+
+/** devuelve la siguiente etapa sugerida que aún no está en rows */
+export function suggestNextStage(rows: Array<{ stage?: string }>) {
+  const current = new Set(
+    rows
+      .map(r => r.stage || "")
+      .map(s => stageByCanonicalOrNull(s))
+      .filter(Boolean) as string[]
+  );
+  for (const s of STAGES) {
+    if (!current.has(s)) return s;
+  }
+  return ""; // no hay sugerencia
+}
+
+function stageByCanonicalOrNull(s: string) {
+  const map: Record<string, string> = {};
+  STAGES.forEach(x => (map[normalize(x)] = x));
+  return map[normalize(s)] || "";
+}

--- a/src/lib/stages.ts
+++ b/src/lib/stages.ts
@@ -1,0 +1,13 @@
+export const STAGES = [
+  "Primera reunión",
+  "NDA",
+  "Entrega de información",
+  "Generación de propuesta",
+  "Presentación de propuesta",
+  "Ajustes técnicos",
+  "LOI",
+  "Revisión de contratos",
+  "Due Diligence",
+  "Cronograma de inversión",
+  "Firma",
+];


### PR DESCRIPTION
## Summary
- add a shared list of pipeline stages and deadline validation helpers
- build a reusable deadlines form with autocomplete inputs and live validation
- wire the new deadlines UX into the admin panel and call the update-investor function

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d98a18fc30832d8e2031a86fe359f3