### PR TITLE
Fix admin route white screen and harden deadlines handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,9 @@
   "version": "0.1.0",
   "private": true,
   "type": "module",
-  "engines": { "node": ">=18" },
+  "engines": {
+    "node": ">=18"
+  },
   "scripts": {
     "dev": "vite",
     "build": "vite build",
@@ -15,6 +17,7 @@
     "react-router-dom": "^6.26.1"
   },
   "devDependencies": {
-    "vite": "^5.4.8"
+    "vite": "^5.4.8",
+    "@vitejs/plugin-react": "^4.2.1"
   }
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,13 +1,14 @@
 import React from 'react'
 import { Routes, Route, NavLink, useLocation } from 'react-router-dom'
-import Dashboard from './pages/Dashboard'
-import Documents from './pages/Documents'
-import Projects from './pages/Projects'
-import Admin from './pages/Admin'
-import Updates from './pages/Updates'
-import NotFound from './pages/NotFound'
+import Dashboard from '@/pages/Dashboard'
+import Documents from '@/pages/Documents'
+import Projects from '@/pages/Projects'
+import AdminPage from '@/pages/Admin'
+import Updates from '@/pages/Updates'
+import NotFound from '@/pages/NotFound'
 import './styles.css'
-import { useInvestorProfile } from './lib/investor'
+import { useInvestorProfile } from '@/lib/investor'
+import { ErrorBoundary } from '@/components/system/ErrorBoundary'
 
 export default function App(){
   const location = useLocation()
@@ -64,14 +65,25 @@ export default function App(){
         </div>
       </header>
       <main className="main">
-        <Routes>
-          <Route path="/" element={<Dashboard />} />
-          <Route path="/projects" element={<Projects />} />
-          <Route path="/documents" element={<Documents />} />
-          <Route path="/updates" element={<Updates />} />
-          {!isInvestorProfile && <Route path="/admin" element={<Admin user={null} />} />}
-          <Route path="*" element={<NotFound />} />
-        </Routes>
+        <ErrorBoundary>
+          <Routes>
+            <Route path="/" element={<Dashboard />} />
+            <Route path="/projects" element={<Projects />} />
+            <Route path="/documents" element={<Documents />} />
+            <Route path="/updates" element={<Updates />} />
+            {!isInvestorProfile && (
+              <Route
+                path="/admin"
+                element={(
+                  <ErrorBoundary>
+                    <AdminPage user={null} />
+                  </ErrorBoundary>
+                )}
+              />
+            )}
+            <Route path="*" element={<NotFound />} />
+          </Routes>
+        </ErrorBoundary>
       </main>
       <div className="footer">© Finsolar Dealroom</div>
     </>

--- a/src/components/deadlines/DeadlinesForm.tsx
+++ b/src/components/deadlines/DeadlinesForm.tsx
@@ -1,59 +1,78 @@
-import { useMemo, useState } from "react";
-import { DeadlinesRow } from "./DeadlinesRow";
-import { validateRows, suggestNextStage } from "@/lib/deadlineValidators";
-import { STAGES } from "@/lib/stages";
+import { useMemo, useState } from "react"
+import { DeadlinesRow } from "./DeadlinesRow"
+import { validateRows, suggestNextStage } from "@/lib/deadlineValidators"
+import { STAGES } from "@/lib/stages"
 
-type Row = { stage?: string; date?: string };
+type Row = { stage?: string; date?: string }
 
 type Props = {
-  initial?: Row[]; // [{stage, date}] opcional
-  onChange?: (rows: Row[]) => void;
-  onSubmit?: (rows: Row[]) => void;
-  saving?: boolean;
-  hideSubmit?: boolean;
-  saveLabel?: string;
-};
+  initial?: Row[]
+  onChange?: (rows: Row[]) => void
+  onSubmit?: (rows: Row[]) => void
+  saving?: boolean
+  hideSubmit?: boolean
+  saveLabel?: string
+}
 
 export function DeadlinesForm({ initial = [], onChange, onSubmit, saving = false, hideSubmit = false, saveLabel = "Guardar" }: Props) {
-  const [rows, setRows] = useState<Row[]>(initial.length ? initial : [{ stage: "", date: "" }]);
+  const safeInitial = Array.isArray(initial) && initial.length ? initial : [{ stage: "", date: "" }]
+  const [rows, setRows] = useState<Row[]>(safeInitial)
 
   const { validation, availableOptions } = useMemo(() => {
-    const v = validateRows(rows);
-    const used = new Set<string>();
-    rows.forEach(r => {
-      const s = r.stage?.trim();
-      if (s) used.add(s);
-    });
-    // opciones por fila: ocultar ya usadas (solo si la fila aún no eligió etapa)
-    const options = rows.map(r => {
-      if (!r.stage) return STAGES.filter(s => !Array.from(used).includes(s));
-      return STAGES;
-    });
-    return {
-      validation: v,
-      availableOptions: options,
-    };
-  }, [rows]);
+    try {
+      const safeRows = Array.isArray(rows) ? rows : []
+      const v = validateRows(safeRows)
+      const used = new Set<string>()
+      safeRows.forEach(r => {
+        const s = r?.stage?.trim()
+        if (s) used.add(s)
+      })
+
+      const options = safeRows.map(r => {
+        if (!r?.stage) {
+          return STAGES.filter(stage => !used.has(stage))
+        }
+        return STAGES
+      })
+
+      return {
+        validation: v,
+        availableOptions: options.length ? options : safeRows.map(() => STAGES),
+      }
+    } catch (e) {
+      console.error("DeadlinesForm memo error:", e)
+      const fallbackRows = Array.isArray(rows) ? rows : []
+      return {
+        validation: { ok: false, message: "Error interno." },
+        availableOptions: fallbackRows.map(() => STAGES),
+      }
+    }
+  }, [rows])
 
   function updateRow(i: number, next: Row) {
-    const copy = rows.slice();
-    copy[i] = next;
-    setRows(copy);
-    onChange?.(copy);
+    setRows(prev => {
+      const base = Array.isArray(prev) ? prev.slice() : []
+      base[i] = next ?? { stage: "", date: "" }
+      onChange?.(base)
+      return base
+    })
   }
 
   function addRow() {
-    const suggestion = suggestNextStage(rows) || "";
-    const next = [...rows, { stage: suggestion, date: "" }];
-    setRows(next);
-    onChange?.(next);
+    setRows(prev => {
+      const safeRows = Array.isArray(prev) ? prev : []
+      const suggestion = suggestNextStage(safeRows) || ""
+      const nextRows = [...safeRows, { stage: suggestion, date: "" }]
+      onChange?.(nextRows)
+      return nextRows
+    })
   }
 
-  const canSave = validation.ok && !saving;
+  const canSave = Boolean(validation?.ok) && !saving
 
   return (
     <div className="space-y-3">
-      {rows.map((r, i) => (
+      {(Array.isArray(rows) ? rows : []).map((r, i) => (
         <DeadlinesRow
           key={i}
           value={r}
@@ -82,8 +101,10 @@ export function DeadlinesForm({ initial = [], onChange, onSubmit, saving = false
             className="px-3 py-2 rounded bg-purple-600 text-white disabled:opacity-50"
             disabled={!canSave}
             onClick={() => {
-              if (!canSave) return;
-              onSubmit?.(rows);
+              if (!canSave) return
+              const currentRows = Array.isArray(rows) ? rows : []
+              if (!Array.isArray(currentRows)) return
+              onSubmit?.(currentRows)
             }}
           >
             {saving ? "Guardando…" : saveLabel}
@@ -91,5 +112,5 @@ export function DeadlinesForm({ initial = [], onChange, onSubmit, saving = false
         )}
       </div>
     </div>
-  );
+  )
 }

--- a/src/components/deadlines/DeadlinesRow.tsx
+++ b/src/components/deadlines/DeadlinesRow.tsx
@@ -1,17 +1,19 @@
-import { useId } from "react";
-import { STAGES } from "@/lib/stages";
+import { useId } from "react"
+import { STAGES } from "@/lib/stages"
 
 type Props = {
-  value: { stage?: string; date?: string };
-  onChange: (v: { stage?: string; date?: string }) => void;
-  stageOptions?: string[]; // para ocultar etapas ya usadas
-  error?: string | null;
-};
+  value?: { stage?: string; date?: string }
+  onChange: (v: { stage?: string; date?: string }) => void
+  stageOptions?: string[]
+  error?: string | null
+}
 
 export function DeadlinesRow({ value, onChange, stageOptions, error }: Props) {
-  const listId = useId();
-  const { stage = "", date = "" } = value || {};
-  const options = stageOptions && stageOptions.length ? stageOptions : STAGES;
+  const generatedId = typeof useId === "function" ? useId() : undefined
+  const listId = generatedId || "stageOptions"
+  const safeValue = value ?? {}
+  const { stage = "", date = "" } = safeValue
+  const options = Array.isArray(stageOptions) && stageOptions.length ? stageOptions : STAGES
 
   return (
     <div className="grid grid-cols-2 gap-3">
@@ -21,7 +23,7 @@ export function DeadlinesRow({ value, onChange, stageOptions, error }: Props) {
           list={listId}
           className="w-full border rounded p-2"
           value={stage}
-          onChange={e => onChange({ ...value, stage: e.target.value })}
+          onChange={e => onChange({ ...safeValue, stage: e.target.value })}
           placeholder="Empieza a escribir…"
         />
         <datalist id={listId}>
@@ -35,11 +37,11 @@ export function DeadlinesRow({ value, onChange, stageOptions, error }: Props) {
           type="date"
           className="w-full border rounded p-2"
           value={date}
-          onChange={e => onChange({ ...value, date: e.target.value })}
+          onChange={e => onChange({ ...safeValue, date: e.target.value })}
         />
       </div>
 
       {error && <div className="col-span-2 text-red-600 text-sm mt-1">{error}</div>}
     </div>
-  );
+  )
 }

--- a/src/components/system/ErrorBoundary.tsx
+++ b/src/components/system/ErrorBoundary.tsx
@@ -1,0 +1,28 @@
+import { Component, ReactNode } from "react"
+
+type Props = { children: ReactNode; fallback?: ReactNode }
+type State = { hasError: boolean; error?: unknown }
+
+export class ErrorBoundary extends Component<Props, State> {
+  state: State = { hasError: false }
+
+  static getDerivedStateFromError(error: unknown) {
+    return { hasError: true, error }
+  }
+
+  componentDidCatch(error: unknown, info: unknown) {
+    console.error("UI ErrorBoundary:", error, info)
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return this.props.fallback ?? (
+        <div style={{ padding: 16 }}>
+          <h2>Algo salió mal al cargar esta vista.</h2>
+          <p>Revisa consola para más detalles.</p>
+        </div>
+      )
+    }
+    return this.props.children
+  }
+}

--- a/src/lib/stages.ts
+++ b/src/lib/stages.ts
@@ -1,4 +1,4 @@
-export const STAGES = [
+export const STAGES: string[] = [
   "Primera reunión",
   "NDA",
   "Entrega de información",
@@ -10,4 +10,4 @@ export const STAGES = [
   "Due Diligence",
   "Cronograma de inversión",
   "Firma",
-];
+]

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,13 +1,21 @@
 import React from 'react'
 import { createRoot } from 'react-dom/client'
 import { HashRouter } from 'react-router-dom'
-import App from './App'
-import { ToastProvider } from './lib/toast'
+import App from '@/App'
+import { ToastProvider } from '@/lib/toast'
+import { ErrorBoundary } from '@/components/system/ErrorBoundary'
+
+if (typeof window !== 'undefined') {
+  window.addEventListener('error', (e) => console.error('GlobalError:', e.error || e.message))
+  window.addEventListener('unhandledrejection', (e) => console.error('UnhandledRejection:', e.reason))
+}
 
 createRoot(document.getElementById('root')).render(
-  <ToastProvider>
-    <HashRouter>
-      <App />
-    </HashRouter>
-  </ToastProvider>
+  <ErrorBoundary>
+    <ToastProvider>
+      <HashRouter>
+        <App />
+      </HashRouter>
+    </ToastProvider>
+  </ErrorBoundary>
 )

--- a/src/pages/Admin.jsx
+++ b/src/pages/Admin.jsx
@@ -1,16 +1,16 @@
 import React, { useCallback, useEffect, useState } from 'react'
-import { api } from '../lib/api'
-import RoleGate from '../components/RoleGate'
-import { DEFAULT_INVESTOR_ID } from '../lib/config'
-import { resolveDeadlineDocTarget } from '../lib/deadlines'
-import { DOCUMENT_SECTIONS_ORDER, DEFAULT_DOC_CATEGORY, DASHBOARD_DOC_CATEGORIES } from '../constants/documents'
-import { PIPELINE_STAGES, FINAL_PIPELINE_STAGE } from '../constants/pipeline'
+import { api } from '@/lib/api'
+import RoleGate from '@/components/RoleGate'
+import { DEFAULT_INVESTOR_ID } from '@/lib/config'
+import { resolveDeadlineDocTarget } from '@/lib/deadlines'
+import { DOCUMENT_SECTIONS_ORDER, DEFAULT_DOC_CATEGORY, DASHBOARD_DOC_CATEGORIES } from '@/constants/documents'
+import { PIPELINE_STAGES, FINAL_PIPELINE_STAGE } from '@/constants/pipeline'
 import { getDecisionBadge, getDecisionDays } from '@/utils/decision'
 import { DeadlinesForm } from '@/components/deadlines/DeadlinesForm'
 import { validateRows } from '@/lib/deadlineValidators'
 import { STAGES } from '@/lib/stages'
-import { useToast } from '../lib/toast'
-import { modalBackdropStyle, modalCardStyle, modalButtonRowStyle } from '../components/modalStyles'
+import { useToast } from '@/lib/toast'
+import { modalBackdropStyle, modalCardStyle, modalButtonRowStyle } from '@/components/modalStyles'
 
 const PORTFOLIO_OPTIONS = [
   { value: 'solarFarms', label: 'Granjas Solares' },
@@ -1237,821 +1237,872 @@ const [activityRefreshKey, setActivityRefreshKey] = useState(0);
 
   return (
     <RoleGate user={user} allow={['admin','ri']}>
-      <div className="container">
-        <div className="h1">Admin / Relaciones con Inversionistas</div>
-        {isAdmin && (
-          <div className="grid" style={{ marginBottom: 16 }}>
-          <div className="card" style={{ gridColumn: 'span 2', minWidth: 280 }}>
-            <div className="row" style={{ justifyContent: 'space-between', alignItems: 'center' }}>
-              <div className="h2" style={{ marginTop: 0 }}>Pipeline global</div>
-              {investorListLoading && <span className="badge">Actualizando…</span>}
-            </div>
-            <div style={{ fontSize: 14, color: 'var(--muted)', marginBottom: 12 }}>
-              Total inversionistas: {numberFormatter.format(pipelineSummary.total || 0)}
-            </div>
-            <div style={{ marginBottom: 16 }}>
-              <div style={{ fontSize: 13, fontWeight: 700 }}>Avance hacia {finalStageLabel || 'cierre'}</div>
-              <div className="progress" style={{ marginTop: 6, height: 12 }}>
-                <div style={{ width: `${Math.min(100, Math.max(0, pipelineSummary.finalPercent || 0))}%` }} />
-              </div>
-              <div style={{ fontSize: 12, color: 'var(--muted)', marginTop: 4 }}>
-                {numberFormatter.format(pipelineSummary.finalCount || 0)} / {numberFormatter.format(pipelineSummary.total || 0)} · {percentFormatter.format(Number.isFinite(pipelineSummary.finalPercent) ? pipelineSummary.finalPercent : 0)}%
-              </div>
-            </div>
-            <div style={{ display: 'grid', gap: 10 }}>
-              {pipelineSummary.counts.map(item => {
-                const safePercent = Number.isFinite(item.percent) ? item.percent : 0
-                return (
-                  <div key={item.stage} style={{ borderTop: '1px solid var(--border)', paddingTop: 8 }}>
-                    <div className="row" style={{ justifyContent: 'space-between', alignItems: 'center', fontSize: 14, fontWeight: 600 }}>
-                      <span>{item.stage}</span>
-                      <span>{numberFormatter.format(item.count)} · {percentFormatter.format(safePercent)}%</span>
-                    </div>
-                    <div className="progress" style={{ marginTop: 6, height: 8 }}>
-                      <div style={{ width: `${Math.min(100, Math.max(0, safePercent))}%` }} />
-                    </div>
-                  </div>
-                )
-              })}
-              {!pipelineSummary.total && (
-                <div style={{ fontSize: 13, color: 'var(--muted)' }}>Sin inversionistas cargados.</div>
-              )}
-            </div>
+      <div className="flex min-h-screen" style={{ display: 'flex', minHeight: '100vh', background: '#f7f7fb' }}>
+        <aside
+          className="w-64 shrink-0 overflow-y-auto border-r"
+          style={{
+            width: 256,
+            flexShrink: 0,
+            overflowY: 'auto',
+            borderRight: '1px solid var(--border)',
+            background: '#fff'
+          }}
+        >
+          <div style={{ padding: 16 }}>
+            <h2 style={{ fontSize: 18, fontWeight: 700, margin: 0 }}>Panel admin</h2>
+            <p style={{ fontSize: 13, color: 'var(--muted)', marginTop: 8 }}>
+              Gestiona inversionistas, documentos y deadlines desde este panel.
+            </p>
+            <ul style={{ listStyle: 'disc', margin: '16px 0 0 20px', padding: 0, color: 'var(--muted)', fontSize: 13 }}>
+              <li>Revisa el pipeline global.</li>
+              <li>Actualiza documentos críticos.</li>
+              <li>Gestiona deadlines y proyectos.</li>
+            </ul>
           </div>
-
-          <div className="card">
-            <div className="row" style={{ justifyContent: 'space-between', alignItems: 'center' }}>
-              <div className="h2" style={{ marginTop: 0 }}>Inversionistas activos</div>
-              <button
-                type="button"
-                className="btn secondary"
-                onClick={loadInvestorList}
-                disabled={investorListLoading}
-              >
-                {investorListLoading ? 'Actualizando…' : 'Actualizar'}
-              </button>
+        </aside>
+        <main className="flex-1 min-w-0" style={{ flex: 1, minWidth: 0, background: '#fff' }}>
+          <header
+            className="sticky top-0 z-10 bg-white/80 backdrop-blur border-b"
+            style={{
+              position: 'sticky',
+              top: 0,
+              zIndex: 10,
+              background: 'rgba(255, 255, 255, 0.92)',
+              backdropFilter: 'blur(6px)',
+              borderBottom: '1px solid var(--border)'
+            }}
+          >
+            <div style={{ padding: '16px 20px' }}>
+              <h1 style={{ margin: 0, fontSize: 24, fontWeight: 700 }}>Admin / Relaciones con Inversionistas</h1>
+              <p style={{ margin: '6px 0 0', fontSize: 14, color: 'var(--muted)' }}>
+                Accede a métricas clave, administra inversionistas y cuida los deadlines.
+              </p>
             </div>
-            <div className="kpi" style={{ marginTop: 4 }}>
-              <div className="num">{investorListLoading ? '—' : numberFormatter.format(pipelineSummary.total || 0)}</div>
-              <div className="label">Total dados de alta</div>
-            </div>
-            {investorListError && <div className="notice" style={{ marginTop: 12 }}>{investorListError}</div>}
-          </div>
-
-          <div className="card">
-            <div className="row" style={{ justifyContent: 'space-between', alignItems: 'center' }}>
-              <div className="h2" style={{ marginTop: 0 }}>Alertas de fechas próximas</div>
-              {investorDetailsLoading && <span className="badge">Cargando…</span>}
-            </div>
-            <label style={{ display: 'flex', alignItems: 'center', gap: 8, fontSize: 13, color: 'var(--muted)', marginBottom: 12 }}>
-              Próximos
-              <input
-                type="number"
-                min="0"
-                className="input"
-                value={deadlineThreshold}
-                onChange={handleDeadlineThresholdChange}
-                style={{ width: 90, padding: '6px 8px' }}
-              />
-              días
-            </label>
-            {upcomingDeadlines.length === 0 && !investorDetailsLoading ? (
-              <div style={{ fontSize: 13, color: 'var(--muted)' }}>Sin alertas dentro del rango configurado.</div>
-            ) : (
-              <ul style={{ listStyle: 'none', padding: 0, margin: 0, display: 'grid', gap: 8 }}>
-                {upcomingDeadlines.map(item => {
-                  const dateLabel = item.formattedDate || item.date || '—'
-                  const dueLabel = item.dueText || (item.days === 0
-                    ? 'Vence hoy'
-                    : `Vence en ${item.days} día${item.days === 1 ? '' : 's'}`)
-                  return (
-                    <li key={`${item.slug}-${item.label}`} style={{ borderTop: '1px solid var(--border)', paddingTop: 8 }}>
-                      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', gap: 12 }}>
-                        <div>
-                          <div style={{ fontWeight: 600 }}>{item.investorName}</div>
+          </header>
+          <div
+            className="h-[calc(100vh-3rem)] overflow-y-auto overflow-x-hidden p-4"
+            style={{ height: 'calc(100vh - 3rem)', overflowY: 'auto', overflowX: 'hidden', padding: 16 }}
+          >
+            <div
+              className="space-y-6"
+              style={{ display: 'flex', flexDirection: 'column', gap: 24, maxWidth: 1120, margin: '0 auto' }}
+            >
+                    {isAdmin && (
+                      <div className="grid" style={{ marginBottom: 16 }}>
+                      <div className="card" style={{ gridColumn: 'span 2', minWidth: 280 }}>
+                        <div className="row" style={{ justifyContent: 'space-between', alignItems: 'center' }}>
+                          <div className="h2" style={{ marginTop: 0 }}>Pipeline global</div>
+                          {investorListLoading && <span className="badge">Actualizando…</span>}
+                        </div>
+                        <div style={{ fontSize: 14, color: 'var(--muted)', marginBottom: 12 }}>
+                          Total inversionistas: {numberFormatter.format(pipelineSummary.total || 0)}
+                        </div>
+                        <div style={{ marginBottom: 16 }}>
+                          <div style={{ fontSize: 13, fontWeight: 700 }}>Avance hacia {finalStageLabel || 'cierre'}</div>
+                          <div className="progress" style={{ marginTop: 6, height: 12 }}>
+                            <div style={{ width: `${Math.min(100, Math.max(0, pipelineSummary.finalPercent || 0))}%` }} />
+                          </div>
                           <div style={{ fontSize: 12, color: 'var(--muted)', marginTop: 4 }}>
-                            {item.label} · {dueLabel} ({dateLabel})
+                            {numberFormatter.format(pipelineSummary.finalCount || 0)} / {numberFormatter.format(pipelineSummary.total || 0)} · {percentFormatter.format(Number.isFinite(pipelineSummary.finalPercent) ? pipelineSummary.finalPercent : 0)}%
                           </div>
                         </div>
-                        {item.docTarget && (
-                          <button
-                            type="button"
-                            className="btn secondary"
-                            onClick={() => navigateToDocsSection(
-                              item.docTarget.category,
-                              item.slug,
-                              item.docTarget.target || 'upload'
-                            )}
-                          >
-                            Ir a {item.docTarget.category}
-                          </button>
-                        )}
-                      </div>
-                    </li>
-                  )
-                })}
-              </ul>
-            )}
-            {investorDetailsError && <div className="notice" style={{ marginTop: 12 }}>{investorDetailsError}</div>}
-          </div>
-
-          <div className="card">
-            <div className="row" style={{ justifyContent: 'space-between', alignItems: 'center' }}>
-              <div className="h2" style={{ marginTop: 0 }}>Faltan documentos</div>
-              <button
-                type="button"
-                className="btn secondary"
-                onClick={handleRefreshDocInventories}
-                disabled={docHealthLoading}
-              >
-                {docHealthLoading ? 'Verificando…' : 'Revisar'}
-              </button>
-            </div>
-            <p style={{ margin: '4px 0 12px', color: 'var(--muted)', fontSize: 13 }}>
-              Estatus por categorías clave.
-            </p>
-            {!investorList.length ? (
-              <div style={{ fontSize: 13, color: 'var(--muted)' }}>Da de alta inversionistas para revisar su documentación.</div>
-            ) : !docInventoriesReady ? (
-              docHealthLoading
-                ? <div style={{ fontSize: 13, color: 'var(--muted)' }}>Verificando documentación…</div>
-                : <div style={{ fontSize: 13, color: 'var(--muted)' }}>No se pudo obtener el estado actual.</div>
-            ) : (
-              docHealthSummary.map(summary => {
-                const previewNames = summary.missing.slice(0, 3).map(item => item.name).join(', ')
-                const remaining = summary.missing.length - Math.min(summary.missing.length, 3)
-                const hasErrors = summary.missing.some(item => item.error)
-                const disabledFolder = summary.total === 0
-                return (
-                  <div key={summary.category} style={{ borderTop: '1px solid var(--border)', paddingTop: 10, marginTop: 10 }}>
-                    <div className="row" style={{ justifyContent: 'space-between', alignItems: 'flex-start', gap: 12 }}>
-                      <div style={{ display: 'flex', gap: 8 }}>
-                        <span style={{ fontSize: 20, lineHeight: 1 }}>{summary.hasAll ? '✅' : '⛔'}</span>
-                        <div>
-                          <div style={{ fontWeight: 700 }}>{summary.category}</div>
-                          <div style={{ fontSize: 13, color: 'var(--muted)' }}>
-                            {summary.total === 0
-                              ? 'Sin inversionistas registrados.'
-                              : summary.hasAll
-                                ? 'Documentación completa.'
-                                : `Faltan ${summary.missing.length} de ${summary.total}.`}
-                          </div>
-                          {!summary.hasAll && summary.missing.length > 0 && (
-                            <div style={{ fontSize: 12, color: 'var(--muted)', marginTop: 4 }}>
-                              {previewNames}
-                              {remaining > 0 && ` +${remaining} más`}
-                            </div>
+                        <div style={{ display: 'grid', gap: 10 }}>
+                          {pipelineSummary.counts.map(item => {
+                            const safePercent = Number.isFinite(item.percent) ? item.percent : 0
+                            return (
+                              <div key={item.stage} style={{ borderTop: '1px solid var(--border)', paddingTop: 8 }}>
+                                <div className="row" style={{ justifyContent: 'space-between', alignItems: 'center', fontSize: 14, fontWeight: 600 }}>
+                                  <span>{item.stage}</span>
+                                  <span>{numberFormatter.format(item.count)} · {percentFormatter.format(safePercent)}%</span>
+                                </div>
+                                <div className="progress" style={{ marginTop: 6, height: 8 }}>
+                                  <div style={{ width: `${Math.min(100, Math.max(0, safePercent))}%` }} />
+                                </div>
+                              </div>
+                            )
+                          })}
+                          {!pipelineSummary.total && (
+                            <div style={{ fontSize: 13, color: 'var(--muted)' }}>Sin inversionistas cargados.</div>
                           )}
                         </div>
                       </div>
-                      <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap', justifyContent: 'flex-end' }}>
-                        <button
-                          type="button"
-                          className="btn secondary"
-                          onClick={() => navigateToDocsSection(summary.category, summary.fallbackSlug, 'upload')}
-                        >
-                          Subir
-                        </button>
-                        <button
-                          type="button"
-                          className="btn secondary"
-                          onClick={() => navigateToDocsSection(summary.category, (summary.folderTarget && summary.folderTarget.slug) || summary.fallbackSlug, 'folder')}
-                          disabled={disabledFolder}
-                        >
-                          Carpeta
-                        </button>
+
+                      <div className="card">
+                        <div className="row" style={{ justifyContent: 'space-between', alignItems: 'center' }}>
+                          <div className="h2" style={{ marginTop: 0 }}>Inversionistas activos</div>
+                          <button
+                            type="button"
+                            className="btn secondary"
+                            onClick={loadInvestorList}
+                            disabled={investorListLoading}
+                          >
+                            {investorListLoading ? 'Actualizando…' : 'Actualizar'}
+                          </button>
+                        </div>
+                        <div className="kpi" style={{ marginTop: 4 }}>
+                          <div className="num">{investorListLoading ? '—' : numberFormatter.format(pipelineSummary.total || 0)}</div>
+                          <div className="label">Total dados de alta</div>
+                        </div>
+                        {investorListError && <div className="notice" style={{ marginTop: 12 }}>{investorListError}</div>}
                       </div>
-                    </div>
-                    {hasErrors && (
-                      <div style={{ fontSize: 12, color: 'var(--muted)', marginTop: 6 }}>
-                        Algunos registros devolvieron errores al consultar sus carpetas.
+
+                      <div className="card">
+                        <div className="row" style={{ justifyContent: 'space-between', alignItems: 'center' }}>
+                          <div className="h2" style={{ marginTop: 0 }}>Alertas de fechas próximas</div>
+                          {investorDetailsLoading && <span className="badge">Cargando…</span>}
+                        </div>
+                        <label style={{ display: 'flex', alignItems: 'center', gap: 8, fontSize: 13, color: 'var(--muted)', marginBottom: 12 }}>
+                          Próximos
+                          <input
+                            type="number"
+                            min="0"
+                            className="input"
+                            value={deadlineThreshold}
+                            onChange={handleDeadlineThresholdChange}
+                            style={{ width: 90, padding: '6px 8px' }}
+                          />
+                          días
+                        </label>
+                        {upcomingDeadlines.length === 0 && !investorDetailsLoading ? (
+                          <div style={{ fontSize: 13, color: 'var(--muted)' }}>Sin alertas dentro del rango configurado.</div>
+                        ) : (
+                          <ul style={{ listStyle: 'none', padding: 0, margin: 0, display: 'grid', gap: 8 }}>
+                            {upcomingDeadlines.map(item => {
+                              const dateLabel = item.formattedDate || item.date || '—'
+                              const dueLabel = item.dueText || (item.days === 0
+                                ? 'Vence hoy'
+                                : `Vence en ${item.days} día${item.days === 1 ? '' : 's'}`)
+                              return (
+                                <li key={`${item.slug}-${item.label}`} style={{ borderTop: '1px solid var(--border)', paddingTop: 8 }}>
+                                  <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', gap: 12 }}>
+                                    <div>
+                                      <div style={{ fontWeight: 600 }}>{item.investorName}</div>
+                                      <div style={{ fontSize: 12, color: 'var(--muted)', marginTop: 4 }}>
+                                        {item.label} · {dueLabel} ({dateLabel})
+                                      </div>
+                                    </div>
+                                    {item.docTarget && (
+                                      <button
+                                        type="button"
+                                        className="btn secondary"
+                                        onClick={() => navigateToDocsSection(
+                                          item.docTarget.category,
+                                          item.slug,
+                                          item.docTarget.target || 'upload'
+                                        )}
+                                      >
+                                        Ir a {item.docTarget.category}
+                                      </button>
+                                    )}
+                                  </div>
+                                </li>
+                              )
+                            })}
+                          </ul>
+                        )}
+                        {investorDetailsError && <div className="notice" style={{ marginTop: 12 }}>{investorDetailsError}</div>}
+                      </div>
+
+                      <div className="card">
+                        <div className="row" style={{ justifyContent: 'space-between', alignItems: 'center' }}>
+                          <div className="h2" style={{ marginTop: 0 }}>Faltan documentos</div>
+                          <button
+                            type="button"
+                            className="btn secondary"
+                            onClick={handleRefreshDocInventories}
+                            disabled={docHealthLoading}
+                          >
+                            {docHealthLoading ? 'Verificando…' : 'Revisar'}
+                          </button>
+                        </div>
+                        <p style={{ margin: '4px 0 12px', color: 'var(--muted)', fontSize: 13 }}>
+                          Estatus por categorías clave.
+                        </p>
+                        {!investorList.length ? (
+                          <div style={{ fontSize: 13, color: 'var(--muted)' }}>Da de alta inversionistas para revisar su documentación.</div>
+                        ) : !docInventoriesReady ? (
+                          docHealthLoading
+                            ? <div style={{ fontSize: 13, color: 'var(--muted)' }}>Verificando documentación…</div>
+                            : <div style={{ fontSize: 13, color: 'var(--muted)' }}>No se pudo obtener el estado actual.</div>
+                        ) : (
+                          docHealthSummary.map(summary => {
+                            const previewNames = summary.missing.slice(0, 3).map(item => item.name).join(', ')
+                            const remaining = summary.missing.length - Math.min(summary.missing.length, 3)
+                            const hasErrors = summary.missing.some(item => item.error)
+                            const disabledFolder = summary.total === 0
+                            return (
+                              <div key={summary.category} style={{ borderTop: '1px solid var(--border)', paddingTop: 10, marginTop: 10 }}>
+                                <div className="row" style={{ justifyContent: 'space-between', alignItems: 'flex-start', gap: 12 }}>
+                                  <div style={{ display: 'flex', gap: 8 }}>
+                                    <span style={{ fontSize: 20, lineHeight: 1 }}>{summary.hasAll ? '✅' : '⛔'}</span>
+                                    <div>
+                                      <div style={{ fontWeight: 700 }}>{summary.category}</div>
+                                      <div style={{ fontSize: 13, color: 'var(--muted)' }}>
+                                        {summary.total === 0
+                                          ? 'Sin inversionistas registrados.'
+                                          : summary.hasAll
+                                            ? 'Documentación completa.'
+                                            : `Faltan ${summary.missing.length} de ${summary.total}.`}
+                                      </div>
+                                      {!summary.hasAll && summary.missing.length > 0 && (
+                                        <div style={{ fontSize: 12, color: 'var(--muted)', marginTop: 4 }}>
+                                          {previewNames}
+                                          {remaining > 0 && ` +${remaining} más`}
+                                        </div>
+                                      )}
+                                    </div>
+                                  </div>
+                                  <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap', justifyContent: 'flex-end' }}>
+                                    <button
+                                      type="button"
+                                      className="btn secondary"
+                                      onClick={() => navigateToDocsSection(summary.category, summary.fallbackSlug, 'upload')}
+                                    >
+                                      Subir
+                                    </button>
+                                    <button
+                                      type="button"
+                                      className="btn secondary"
+                                      onClick={() => navigateToDocsSection(summary.category, (summary.folderTarget && summary.folderTarget.slug) || summary.fallbackSlug, 'folder')}
+                                      disabled={disabledFolder}
+                                    >
+                                      Carpeta
+                                    </button>
+                                  </div>
+                                </div>
+                                {hasErrors && (
+                                  <div style={{ fontSize: 12, color: 'var(--muted)', marginTop: 6 }}>
+                                    Algunos registros devolvieron errores al consultar sus carpetas.
+                                  </div>
+                                )}
+                              </div>
+                            )
+                          })
+                        )}
+                        {docHealthError && <div className="notice" style={{ marginTop: 12 }}>{docHealthError}</div>}
+                      </div>
+
+                      <div className="card" style={{ gridColumn: 'span 2', minWidth: 280 }}>
+                        <div className="row" style={{ justifyContent: 'space-between', alignItems: 'center' }}>
+                          <div className="h2" style={{ marginTop: 0 }}>Actividad reciente</div>
+                          <button
+                            type="button"
+                            className="btn secondary"
+                            onClick={handleRefreshActivity}
+                            disabled={activityLoading}
+                          >
+                            {activityLoading ? 'Consultando…' : 'Actualizar'}
+                          </button>
+                        </div>
+                        {activityError && <div className="notice" style={{ marginTop: 12 }}>{activityError}</div>}
+                        {activityLoading && <div style={{ marginTop: 12, color: 'var(--muted)' }}>Consultando actividad…</div>}
+                        {!activityLoading && !activityError && activityDisplayItems.length === 0 && (
+                          <div style={{ marginTop: 12, color: 'var(--muted)', fontSize: 13 }}>Sin eventos recientes.</div>
+                        )}
+                        {activityDisplayItems.length > 0 && (
+                          <ul style={{ listStyle: 'none', margin: 12, marginTop: 12, padding: 0, display: 'grid', gap: 10 }}>
+                            {activityDisplayItems.map(item => (
+                              <li key={item.key} style={{ borderTop: '1px solid var(--border)', paddingTop: 8 }}>
+                                <div style={{ display: 'flex', gap: 10, alignItems: 'flex-start' }}>
+                                  <span style={{ fontSize: 18, lineHeight: 1 }}>{item.icon}</span>
+                                  <div>
+                                    <div style={{ fontWeight: 600 }}>{item.title}</div>
+                                    {item.detail && <div style={{ fontSize: 12, color: 'var(--muted)', marginTop: 2 }}>{item.detail}</div>}
+                                    <div style={{ fontSize: 12, color: 'var(--muted)', marginTop: 2 }}>{item.dateLabel}</div>
+                                  </div>
+                                </div>
+                              </li>
+                            ))}
+                          </ul>
+                        )}
+                      </div>
                       </div>
                     )}
-                  </div>
-                )
-              })
-            )}
-            {docHealthError && <div className="notice" style={{ marginTop: 12 }}>{docHealthError}</div>}
-          </div>
-
-          <div className="card" style={{ gridColumn: 'span 2', minWidth: 280 }}>
-            <div className="row" style={{ justifyContent: 'space-between', alignItems: 'center' }}>
-              <div className="h2" style={{ marginTop: 0 }}>Actividad reciente</div>
-              <button
-                type="button"
-                className="btn secondary"
-                onClick={handleRefreshActivity}
-                disabled={activityLoading}
-              >
-                {activityLoading ? 'Consultando…' : 'Actualizar'}
-              </button>
-            </div>
-            {activityError && <div className="notice" style={{ marginTop: 12 }}>{activityError}</div>}
-            {activityLoading && <div style={{ marginTop: 12, color: 'var(--muted)' }}>Consultando actividad…</div>}
-            {!activityLoading && !activityError && activityDisplayItems.length === 0 && (
-              <div style={{ marginTop: 12, color: 'var(--muted)', fontSize: 13 }}>Sin eventos recientes.</div>
-            )}
-            {activityDisplayItems.length > 0 && (
-              <ul style={{ listStyle: 'none', margin: 12, marginTop: 12, padding: 0, display: 'grid', gap: 10 }}>
-                {activityDisplayItems.map(item => (
-                  <li key={item.key} style={{ borderTop: '1px solid var(--border)', paddingTop: 8 }}>
-                    <div style={{ display: 'flex', gap: 10, alignItems: 'flex-start' }}>
-                      <span style={{ fontSize: 18, lineHeight: 1 }}>{item.icon}</span>
-                      <div>
-                        <div style={{ fontWeight: 600 }}>{item.title}</div>
-                        {item.detail && <div style={{ fontSize: 12, color: 'var(--muted)', marginTop: 2 }}>{item.detail}</div>}
-                        <div style={{ fontSize: 12, color: 'var(--muted)', marginTop: 2 }}>{item.dateLabel}</div>
-                      </div>
-                    </div>
-                  </li>
-                ))}
-              </ul>
-            )}
-          </div>
-          </div>
-        )}
-        <div className="card" style={{marginBottom:12}}>
-          <div className="h2">Alta de Inversionista</div>
-          <form onSubmit={onCreate} aria-busy={invLoading}>
-            <div className="form-row">
-              <input className="input" type="email" placeholder="Email corporativo" value={inv.email} onChange={e => setInv({ ...inv, email: e.target.value })} required />
-              <input className="input" placeholder="Nombre de la empresa" value={inv.companyName} onChange={e => setInv({ ...inv, companyName: e.target.value })} required />
-              <input className="input" placeholder="Slug deseado (opcional)" value={inv.slug} onChange={e => setInv({ ...inv, slug: e.target.value })} />
-              <select className="select" value={inv.status} onChange={e => setInv({ ...inv, status: e.target.value })}>
-                {PIPELINE_STAGES.map(s => <option key={s}>{s}</option>)}
-              </select>
-            </div>
-            <div style={{marginTop:8}}>
-              <DeadlinesForm
-                key={invDeadlinesKey}
-                initial={inv.deadlines}
-                onChange={rows => setInv(prev => ({ ...prev, deadlines: ensureDeadlineRows(rows) }))}
-                hideSubmit
-              />
-            </div>
-            <button className="btn" type="submit" disabled={invLoading} style={{marginTop:8}}>
-              {invLoading ? 'Creando…' : 'Crear'}
-            </button>
-          </form>
-          {invLoading && <div className="progress" style={{marginTop:8}}><div style={{width: progress + '%'}} /></div>}
-          {invMsg && (
-            <div className="notice" style={{marginTop:8, display:'flex', alignItems:'center', justifyContent:'space-between'}}>
-              <span style={{wordBreak:'break-all'}}>{invMsg}</span>
-              <button className="btn" type="button" onClick={() => navigator.clipboard && navigator.clipboard.writeText(invMsg)}>Copiar</button>
-            </div>
-          )}
-          {invErr && <div className="notice" style={{marginTop:8}}>{invErr}</div>}
-        </div>
-        {isAdmin && (
-          <div className="card" style={{marginBottom:12}}>
-            <div className="h2">Inversionistas activos</div>
-            <p style={{marginTop:0, marginBottom:12, color:'var(--muted)', fontSize:14}}>
-              Consulta los inversionistas dados de alta y dales de baja cuando sea necesario.
-            </p>
-            <div className="form-row" style={{marginBottom:12}}>
-              <input
-                className="input"
-                placeholder="Buscar por nombre, correo o slug"
-                value={investorSearch}
-                onChange={e => setInvestorSearch(e.target.value)}
-              />
-              <button
-                type="button"
-                className="btn secondary"
-                onClick={loadInvestorList}
-                disabled={investorListLoading}
-              >
-                {investorListLoading ? 'Actualizando...' : 'Actualizar lista'}
-              </button>
-            </div>
-            {investorListError && <div className="notice" style={{marginBottom:12}}>{investorListError}</div>}
-            {investorDeleteErr && <div className="notice" style={{marginBottom:12}}>{investorDeleteErr}</div>}
-            {investorDeleteMsg && <div className="notice" style={{marginBottom:12}}>{investorDeleteMsg}</div>}
-            <div style={{fontSize:13, color:'var(--muted)', marginBottom:8}}>
-              {investorListLoading
-                ? 'Cargando inversionistas...'
-                : `${filteredInvestorCount} inversionista${filteredInvestorCount === 1 ? '' : 's'} coincidente${filteredInvestorCount === 1 ? '' : 's'}`}
-            </div>
-            <div style={{overflowX:'auto'}}>
-              <table className="table">
-                <thead>
-                  <tr>
-                    <th style={{minWidth:140}}>Empresa</th>
-                    <th style={{minWidth:180}}>Correo</th>
-                    <th style={{minWidth:100}}>Slug</th>
-                    <th style={{minWidth:120}}>Estado</th>
-                    <th style={{minWidth:120}}>Acciones</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {investorListLoading && (
-                    <tr>
-                      <td colSpan={5} style={{paddingTop:12, paddingBottom:12}}>Cargando datos...</td>
-                    </tr>
-                  )}
-                  {!investorListLoading && filteredInvestors.map(item => (
-                    <tr key={item.slug}>
-                      <td>{item.name || '—'}</td>
-                      <td>{item.email || '—'}</td>
-                      <td>{item.slug}</td>
-                      <td>{item.status || '—'}</td>
-                      <td>
-                        <button
-                          type="button"
-                          className="btn secondary"
-                          onClick={() => handleDeleteInvestor(item.slug)}
-                          disabled={deletingInvestor === item.slug}
-                        >
-                          {deletingInvestor === item.slug ? 'Eliminando...' : 'Eliminar'}
-                        </button>
-                      </td>
-                    </tr>
-                  ))}
-                  {!investorListLoading && filteredInvestors.length === 0 && (
-                    <tr>
-                      <td colSpan={5} style={{paddingTop:12, paddingBottom:12, color:'var(--muted)'}}>
-                        No se encontraron inversionistas con los criterios actuales.
-                      </td>
-                    </tr>
-                  )}
-                </tbody>
-              </table>
-            </div>
-          </div>
-        )}
-        <div className="card">
-          <div className="h2">Actualizar estado de inversionista</div>
-          <form onSubmit={onSubmit}>
-            <div className="form-row">
-              <input
-                className="input"
-                placeholder="slug (id)"
-                value={payload.id}
-                onChange={e => setPayload({ ...payload, id: e.target.value })}
-              />
-              <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
-                <button
-                  type="button"
-                  className="btn secondary"
-                  onClick={handleLoadInvestor}
-                  disabled={investorLoading || !canLoadInvestor}
-                >
-                  {investorLoading ? 'Cargando...' : 'Cargar datos'}
-                </button>
-                <button
-                  type="button"
-                  className="btn secondary"
-                  onClick={handleOpenPanelModal}
-                  disabled={!canLoadInvestor}
-                >
-                  Ver panel
-                </button>
-                <button
-                  type="button"
-                  className="btn secondary"
-                  onClick={handleOpenDeleteModal}
-                  disabled={!canLoadInvestor || deletingInvestor === normalizedPayloadSlug}
-                >
-                  {deletingInvestor === normalizedPayloadSlug ? 'Eliminando...' : 'Eliminar'}
-                </button>
-              </div>
-              <input
-                className="input"
-                placeholder="Nombre"
-                value={payload.name}
-                onChange={e => setPayload({ ...payload, name: e.target.value })}
-              />
-              <select
-                className="select"
-                value={payload.status}
-                onChange={e => setPayload({ ...payload, status: e.target.value })}
-              >
-                {PIPELINE_STAGES.map(s => <option key={s}>{s}</option>)}
-              </select>
-            </div>
-
-            <div style={{ marginTop: 12, fontWeight: 700 }}>Deadlines</div>
-            <div style={{ marginTop: 8 }}>
-              <DeadlinesForm
-                key={deadlineFormKey}
-                initial={deadlineRows}
-                onChange={handleDeadlinesChange}
-                onSubmit={handleDeadlinesSubmit}
-                saving={deadlinesSaving}
-              />
-              {deadlinesMsg && (
-                <div className="notice" style={{ marginTop: 8 }}>{deadlinesMsg}</div>
-              )}
-              {deadlinesErr && (
-                <div className="notice" style={{ marginTop: 8 }}>{deadlinesErr}</div>
-              )}
-            </div>
-
-            <div style={{ marginTop: 12, fontWeight: 700 }}>Métricas clave</div>
-
-            <div className="form-row" style={{ marginTop: 8 }}>
-              <div style={fieldStyle}>
-                <div style={labelStyle}>Días a decisión</div>
-                <span className={decisionBadgeClass}>{decisionLabel}</span>
-              </div>
-              <div style={fieldStyle}>
-                <label htmlFor="metric-fiscal" style={labelStyle}>Inversión de capital fiscal (MXN)</label>
-                <input
-                  id="metric-fiscal"
-                  className="input"
-                  type="number"
-                  min="0"
-                  step="any"
-                  value={metrics.fiscalCapitalInvestment ?? ''}
-                  onChange={e => updateMetric('fiscalCapitalInvestment', e.target.value)}
-                />
-              </div>
-            </div>
-
-            <div className="form-row" style={{ marginTop: 8 }}>
-              <div style={fieldStyle}>
-                <label htmlFor="metric-project-amount" style={labelStyle}>Utilidad de proyecto (MXN)</label>
-                <input
-                  id="metric-project-amount"
-                  className="input"
-                  type="number"
-                  min="0"
-                  step="any"
-                  value={projectProfitability.amount ?? ''}
-                  onChange={e => updateMetric('projectProfitability', current => ({ ...(current || {}), amount: e.target.value }))}
-                />
-              </div>
-              <div style={fieldStyle}>
-                <label htmlFor="metric-project-years" style={labelStyle}>Horizonte (años)</label>
-                <input
-                  id="metric-project-years"
-                  className="input"
-                  type="number"
-                  min="0"
-                  value={projectProfitability.years ?? ''}
-                  onChange={e => updateMetric('projectProfitability', current => ({ ...(current || {}), years: e.target.value }))}
-                />
-              </div>
-            </div>
-
-            <div className="form-row" style={{ marginTop: 8 }}>
-              <div style={fieldStyle}>
-                <label htmlFor="metric-portfolio-type" style={labelStyle}>Portafolio</label>
-                <select
-                  id="metric-portfolio-type"
-                  className="select"
-                  value={portfolio.type || ''}
-                  onChange={e => handlePortfolioTypeChange(e.target.value)}
-                >
-                  <option value="">Selecciona una opción</option>
-                  {PORTFOLIO_OPTIONS.map(opt => (
-                    <option key={opt.value} value={opt.value}>{opt.label}</option>
-                  ))}
-                </select>
-              </div>
-            </div>
-
-            {isPortfolioMix && (
-              <div style={{ marginTop: 8 }}>
-                <div className="form-row">
-                  {MIX_FIELDS.map(field => (
-                    <div key={field.key} style={mixFieldStyle}>
-                      <label htmlFor={`metric-portfolio-${field.key}`} style={labelStyle}>{field.label} (%)</label>
-                      <input
-                        id={`metric-portfolio-${field.key}`}
-                        className="input"
-                        type="number"
-                        min="0"
-                        max="100"
-                        step="any"
-                        value={mixValues[field.key] ?? ''}
-                        onChange={e => handleMixChange(field.key, e.target.value)}
-                      />
-                    </div>
-                  ))}
-                </div>
-                <div style={{ marginTop: 4, fontSize: 12, color: 'var(--muted)' }}>Suma: {mixTotal}%</div>
-              </div>
-            )}
-
-            <button className="btn" type="submit" style={{ marginTop: 12 }}>Guardar</button>
-          </form>
-          {msg && <div className="notice" style={{marginTop:8}}>{msg}</div>}
-          {err && <div className="notice" style={{marginTop:8}}>{err}</div>}
-        </div>
-        <div className="card" style={{marginTop:12}} ref={docsCardRef}>
-          <div className="h2">Documentos por inversionista</div>
-          <form
-            onSubmit={handleDocSlugSubmit}
-            className="form-row"
-            style={{ marginTop: 8, alignItems: 'flex-end', gap: 12 }}
-          >
-            <div style={{ ...fieldStyle, minWidth: 200 }}>
-              <label htmlFor="docs-slug" style={labelStyle}>Slug del inversionista</label>
-              <input
-                id="docs-slug"
-                className="input"
-                value={docSlugInput}
-                onChange={e => setDocSlugInput(e.target.value)}
-                placeholder="slug"
-              />
-            </div>
-            <div style={{ ...fieldStyle, minWidth: 200 }}>
-              <label htmlFor="docs-category" style={labelStyle}>Categoría</label>
-              <select
-                id="docs-category"
-                className="select"
-                value={docCategory}
-                onChange={e => { setDocCategory(e.target.value); setDocsNotice(null); setDocsError(null) }}
-              >
-                {DOCUMENT_SECTIONS_ORDER.map(cat => (
-                  <option key={cat} value={cat}>{cat}</option>
-                ))}
-              </select>
-            </div>
-            <button className="btn" type="submit" disabled={docsLoading || docsWorking}>Ver carpeta</button>
-            <button
-              className="btn secondary"
-              type="button"
-              onClick={() => { setDocsNotice(null); setDocsError(null); loadDocs() }}
-              disabled={docsLoading || docsWorking}
-            >
-              Actualizar
-            </button>
-          </form>
-          <div style={{ marginTop: 8, fontSize: 13, color: 'var(--muted)' }}>
-            Gestionando: <code>{docCategory}/{effectiveDocSlug}</code>
-          </div>
-          <form onSubmit={handleDocUpload} className="form-row" style={{ marginTop: 12 }} aria-busy={docsWorking}>
-            <input name="file" type="file" className="input" disabled={docsWorking} ref={docsUploadInputRef} />
-            <button className="btn" type="submit" disabled={docsWorking}>
-              {docsWorking ? 'Subiendo…' : 'Subir'}
-            </button>
-            <span className="notice">Los archivos se guardan en GitHub.</span>
-          </form>
-          {docsError && <div className="notice" style={{marginTop:8}}>{docsError}</div>}
-          {docsNotice && <div className="notice" style={{marginTop:8}}>{docsNotice}</div>}
-          {docsWorking && !docsLoading && <div style={{marginTop:8, color:'var(--muted)'}}>Procesando...</div>}
-          {docsLoading && <div style={{marginTop:8, color:'var(--muted)'}}>Cargando documentos...</div>}
-          <table className="table" style={{ marginTop: 12 }} ref={docsTableRef}>
-            <thead>
-              <tr>
-                <th>Archivo</th>
-                <th>Tamaño</th>
-                <th></th>
-              </tr>
-            </thead>
-            <tbody>
-              {docList.map(file => (
-                <tr key={file.path}>
-                  <td>{file.name}</td>
-                  <td>{(file.size / 1024).toFixed(1)} KB</td>
-                  <td style={{ display: 'flex', gap: 8, justifyContent: 'flex-end' }}>
-                    <a
-                      className="btn secondary"
-                      href={api.downloadDocPath(file.path)}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                    >
-                      Descargar
-                    </a>
-                    <button
-                      type="button"
-                      className="btn secondary"
-                      onClick={() => handleDocDelete(file)}
-                      disabled={docsWorking}
-                    >
-                      Eliminar
-                    </button>
-                  </td>
-                </tr>
-              ))}
-              {!docList.length && !docsLoading && (
-                <tr>
-                  <td colSpan="3">No hay documentos en esta carpeta.</td>
-                </tr>
-              )}
-            </tbody>
-          </table>
-        </div>
-        {docRenamePrompt && (
-          <div style={modalBackdropStyle} role="dialog" aria-modal="true" aria-labelledby="doc-rename-title">
-            <div style={modalCardStyle}>
-              <div className="h2" id="doc-rename-title" style={{ marginTop: 0 }}>Archivo duplicado</div>
-              <p style={{ marginTop: 8, color: 'var(--muted)', fontSize: 14 }}>
-                Ya existe un archivo con ese nombre. ¿Quieres subirlo con un sufijo automático?
-              </p>
-              <p style={{ fontSize: 13 }}>
-                <code>{docRenamePrompt.path}</code>
-              </p>
-              <div style={modalButtonRowStyle}>
-                <button
-                  type="button"
-                  className="btn secondary"
-                  onClick={handleCancelDocRename}
-                  disabled={docsWorking}
-                >
-                  Cancelar
-                </button>
-                <button
-                  type="button"
-                  className="btn"
-                  onClick={handleConfirmDocRename}
-                  disabled={docsWorking}
-                  aria-busy={docsWorking}
-                >
-                  {docsWorking ? 'Subiendo…' : 'Renombrar y subir'}
-                </button>
-              </div>
-            </div>
-          </div>
-        )}
-        <div className="card" style={{marginTop:12}}>
-          <div className="h2">Gestionar proyectos activos</div>
-          <p style={{ margin: 0, color: 'var(--muted)', fontSize: 14 }}>Actualiza la lista que aparece en la sección de Proyectos.</p>
-          {projectLoadErr && <div className="notice" style={{marginTop:8}}>{projectLoadErr}</div>}
-          {projectsLoading ? (
-            <div style={{marginTop:8, color:'var(--muted)'}}>Cargando proyectos...</div>
-          ) : (
-            <form onSubmit={onSaveProjects}>
-              {projectList.map((project, index) => (
-                <div key={project.id || index} style={projectBoxStyle}>
-                  <div className="row" style={{justifyContent:'space-between'}}>
-                    <div style={{fontWeight:700}}>{project.name || project.id || `Proyecto ${index + 1}`}</div>
-                    <button
-                      type="button"
-                      className="btn secondary"
-                      style={{padding:'6px 12px', fontSize:12}}
-                      onClick={() => removeProject(index)}
-                    >
-                      Eliminar
-                    </button>
-                  </div>
-                  <div className="form-row" style={{marginTop:8}}>
-                    <div style={fieldStyle}>
-                      <label htmlFor={`project-${index}-id`} style={labelStyle}>ID</label>
-                      <input
-                        id={`project-${index}-id`}
-                        className="input"
-                        value={project.id}
-                        onChange={e => updateProjectField(index, 'id', e.target.value)}
-                      />
-                    </div>
-                    <div style={fieldStyle}>
-                      <label htmlFor={`project-${index}-name`} style={labelStyle}>Nombre</label>
-                      <input
-                        id={`project-${index}-name`}
-                        className="input"
-                        value={project.name}
-                        onChange={e => updateProjectField(index, 'name', e.target.value)}
-                      />
-                    </div>
-                    <div style={fieldStyle}>
-                      <label htmlFor={`project-${index}-client`} style={labelStyle}>Cliente</label>
-                      <input
-                        id={`project-${index}-client`}
-                        className="input"
-                        value={project.client}
-                        onChange={e => updateProjectField(index, 'client', e.target.value)}
-                      />
-                    </div>
-                  </div>
-                  <div className="form-row" style={{marginTop:8}}>
-                    <div style={fieldStyle}>
-                      <label htmlFor={`project-${index}-location`} style={labelStyle}>Ubicación</label>
-                      <input
-                        id={`project-${index}-location`}
-                        className="input"
-                        value={project.location}
-                        onChange={e => updateProjectField(index, 'location', e.target.value)}
-                      />
-                    </div>
-                    <div style={fieldStyle}>
-                      <label htmlFor={`project-${index}-model`} style={labelStyle}>Modelo</label>
-                      <input
-                        id={`project-${index}-model`}
-                        className="input"
-                        value={project.model}
-                        onChange={e => updateProjectField(index, 'model', e.target.value)}
-                      />
-                    </div>
-                    <div style={fieldStyle}>
-                      <label htmlFor={`project-${index}-status`} style={labelStyle}>Estado</label>
-                      <input
-                        id={`project-${index}-status`}
-                        className="input"
-                        value={project.status}
-                        onChange={e => updateProjectField(index, 'status', e.target.value)}
-                      />
-                    </div>
-                  </div>
-                  <div className="form-row" style={{marginTop:8}}>
-                    {PROJECT_NUMBER_FIELDS.map(field => (
-                      <div key={field.key} style={fieldStyle}>
-                        <label htmlFor={`project-${index}-${field.key}`} style={labelStyle}>{field.label}</label>
-                        <input
-                          id={`project-${index}-${field.key}`}
-                          className="input"
-                          type="number"
-                          min="0"
-                          step="any"
-                          value={project[field.key] ?? ''}
-                          onChange={e => updateProjectField(index, field.key, e.target.value)}
-                        />
-                      </div>
-                    ))}
-                  </div>
-                  <div className="form-row" style={{marginTop:8}}>
-                    <div style={fieldStyle}>
-                      <label htmlFor={`project-${index}-termMonths`} style={labelStyle}>Plazo (meses)</label>
-                      <input
-                        id={`project-${index}-termMonths`}
-                        className="input"
-                        type="number"
-                        min="0"
-                        step="1"
-                        value={project.termMonths ?? 0}
-                        onChange={e => updateProjectField(index, 'termMonths', e.target.value)}
-                      />
-                    </div>
-                    <div style={fieldStyle}>
-                      <label htmlFor={`project-${index}-empresa`} style={labelStyle}>Empresa</label>
-                      <input
-                        id={`project-${index}-empresa`}
-                        className="input"
-                        type="text"
-                        value={project.empresa ?? ''}
-                        onChange={e => updateProjectField(index, 'empresa', e.target.value)}
-                        placeholder="Razón social / filial"
-                      />
-                    </div>
-                    <div style={fieldStyle}>
-                      <label htmlFor={`project-${index}-imageUrl`} style={labelStyle}>Imagen (URL)</label>
-                      <input
-                        id={`project-${index}-imageUrl`}
-                        className="input"
-                        type="url"
-                        placeholder="https://..."
-                        value={project.imageUrl ?? ''}
-                        onChange={e => updateProjectField(index, 'imageUrl', e.target.value)}
-                      />
-                      {project.imageUrl && /^https?:\/\//i.test(project.imageUrl) && (
-                        <div style={{ marginTop: 8 }}>
-                          <img
-                            src={project.imageUrl}
-                            alt={project.name || project.id || 'Proyecto'}
-                            style={{ maxWidth: 160, borderRadius: 8 }}
+                    <div className="card" style={{marginBottom:12}}>
+                      <div className="h2">Alta de Inversionista</div>
+                      <form onSubmit={onCreate} aria-busy={invLoading}>
+                        <div className="form-row">
+                          <input className="input" type="email" placeholder="Email corporativo" value={inv.email} onChange={e => setInv({ ...inv, email: e.target.value })} required />
+                          <input className="input" placeholder="Nombre de la empresa" value={inv.companyName} onChange={e => setInv({ ...inv, companyName: e.target.value })} required />
+                          <input className="input" placeholder="Slug deseado (opcional)" value={inv.slug} onChange={e => setInv({ ...inv, slug: e.target.value })} />
+                          <select className="select" value={inv.status} onChange={e => setInv({ ...inv, status: e.target.value })}>
+                            {PIPELINE_STAGES.map(s => <option key={s}>{s}</option>)}
+                          </select>
+                        </div>
+                        <div style={{marginTop:8}}>
+                          <DeadlinesForm
+                            key={invDeadlinesKey}
+                            initial={inv.deadlines}
+                            onChange={rows => setInv(prev => ({ ...prev, deadlines: ensureDeadlineRows(rows) }))}
+                            hideSubmit
                           />
                         </div>
+                        <button className="btn" type="submit" disabled={invLoading} style={{marginTop:8}}>
+                          {invLoading ? 'Creando…' : 'Crear'}
+                        </button>
+                      </form>
+                      {invLoading && <div className="progress" style={{marginTop:8}}><div style={{width: progress + '%'}} /></div>}
+                      {invMsg && (
+                        <div className="notice" style={{marginTop:8, display:'flex', alignItems:'center', justifyContent:'space-between'}}>
+                          <span style={{wordBreak:'break-all'}}>{invMsg}</span>
+                          <button className="btn" type="button" onClick={() => navigator.clipboard && navigator.clipboard.writeText(invMsg)}>Copiar</button>
+                        </div>
                       )}
+                      {invErr && <div className="notice" style={{marginTop:8}}>{invErr}</div>}
                     </div>
-                  </div>
-                  <div className="form-row" style={{marginTop:8}}>
-                    <div style={{ ...fieldStyle, minWidth: 260 }}>
-                      <label htmlFor={`project-${index}-notes`} style={labelStyle}>Notas</label>
-                      <textarea
-                        id={`project-${index}-notes`}
-                        className="input"
-                        style={noteAreaStyle}
-                        value={project.notes}
-                        onChange={e => updateProjectField(index, 'notes', e.target.value)}
-                      />
+                    {isAdmin && (
+                      <div className="card" style={{marginBottom:12}}>
+                        <div className="h2">Inversionistas activos</div>
+                        <p style={{marginTop:0, marginBottom:12, color:'var(--muted)', fontSize:14}}>
+                          Consulta los inversionistas dados de alta y dales de baja cuando sea necesario.
+                        </p>
+                        <div className="form-row" style={{marginBottom:12}}>
+                          <input
+                            className="input"
+                            placeholder="Buscar por nombre, correo o slug"
+                            value={investorSearch}
+                            onChange={e => setInvestorSearch(e.target.value)}
+                          />
+                          <button
+                            type="button"
+                            className="btn secondary"
+                            onClick={loadInvestorList}
+                            disabled={investorListLoading}
+                          >
+                            {investorListLoading ? 'Actualizando...' : 'Actualizar lista'}
+                          </button>
+                        </div>
+                        {investorListError && <div className="notice" style={{marginBottom:12}}>{investorListError}</div>}
+                        {investorDeleteErr && <div className="notice" style={{marginBottom:12}}>{investorDeleteErr}</div>}
+                        {investorDeleteMsg && <div className="notice" style={{marginBottom:12}}>{investorDeleteMsg}</div>}
+                        <div style={{fontSize:13, color:'var(--muted)', marginBottom:8}}>
+                          {investorListLoading
+                            ? 'Cargando inversionistas...'
+                            : `${filteredInvestorCount} inversionista${filteredInvestorCount === 1 ? '' : 's'} coincidente${filteredInvestorCount === 1 ? '' : 's'}`}
+                        </div>
+                        <div style={{overflowX:'auto'}}>
+                          <table className="table">
+                            <thead>
+                              <tr>
+                                <th style={{minWidth:140}}>Empresa</th>
+                                <th style={{minWidth:180}}>Correo</th>
+                                <th style={{minWidth:100}}>Slug</th>
+                                <th style={{minWidth:120}}>Estado</th>
+                                <th style={{minWidth:120}}>Acciones</th>
+                              </tr>
+                            </thead>
+                            <tbody>
+                              {investorListLoading && (
+                                <tr>
+                                  <td colSpan={5} style={{paddingTop:12, paddingBottom:12}}>Cargando datos...</td>
+                                </tr>
+                              )}
+                              {!investorListLoading && filteredInvestors.map(item => (
+                                <tr key={item.slug}>
+                                  <td>{item.name || '—'}</td>
+                                  <td>{item.email || '—'}</td>
+                                  <td>{item.slug}</td>
+                                  <td>{item.status || '—'}</td>
+                                  <td>
+                                    <button
+                                      type="button"
+                                      className="btn secondary"
+                                      onClick={() => handleDeleteInvestor(item.slug)}
+                                      disabled={deletingInvestor === item.slug}
+                                    >
+                                      {deletingInvestor === item.slug ? 'Eliminando...' : 'Eliminar'}
+                                    </button>
+                                  </td>
+                                </tr>
+                              ))}
+                              {!investorListLoading && filteredInvestors.length === 0 && (
+                                <tr>
+                                  <td colSpan={5} style={{paddingTop:12, paddingBottom:12, color:'var(--muted)'}}>
+                                    No se encontraron inversionistas con los criterios actuales.
+                                  </td>
+                                </tr>
+                              )}
+                            </tbody>
+                          </table>
+                        </div>
+                      </div>
+                    )}
+                    <div className="card">
+                      <div className="h2">Actualizar estado de inversionista</div>
+                      <form onSubmit={onSubmit}>
+                        <div className="form-row">
+                          <input
+                            className="input"
+                            placeholder="slug (id)"
+                            value={payload.id}
+                            onChange={e => setPayload({ ...payload, id: e.target.value })}
+                          />
+                          <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
+                            <button
+                              type="button"
+                              className="btn secondary"
+                              onClick={handleLoadInvestor}
+                              disabled={investorLoading || !canLoadInvestor}
+                            >
+                              {investorLoading ? 'Cargando...' : 'Cargar datos'}
+                            </button>
+                            <button
+                              type="button"
+                              className="btn secondary"
+                              onClick={handleOpenPanelModal}
+                              disabled={!canLoadInvestor}
+                            >
+                              Ver panel
+                            </button>
+                            <button
+                              type="button"
+                              className="btn secondary"
+                              onClick={handleOpenDeleteModal}
+                              disabled={!canLoadInvestor || deletingInvestor === normalizedPayloadSlug}
+                            >
+                              {deletingInvestor === normalizedPayloadSlug ? 'Eliminando...' : 'Eliminar'}
+                            </button>
+                          </div>
+                          <input
+                            className="input"
+                            placeholder="Nombre"
+                            value={payload.name}
+                            onChange={e => setPayload({ ...payload, name: e.target.value })}
+                          />
+                          <select
+                            className="select"
+                            value={payload.status}
+                            onChange={e => setPayload({ ...payload, status: e.target.value })}
+                          >
+                            {PIPELINE_STAGES.map(s => <option key={s}>{s}</option>)}
+                          </select>
+                        </div>
+
+                        <div style={{ marginTop: 12, fontWeight: 700 }}>Deadlines</div>
+                        <div style={{ marginTop: 8 }}>
+                          <DeadlinesForm
+                            key={deadlineFormKey}
+                            initial={deadlineRows}
+                            onChange={handleDeadlinesChange}
+                            onSubmit={handleDeadlinesSubmit}
+                            saving={deadlinesSaving}
+                          />
+                          {deadlinesMsg && (
+                            <div className="notice" style={{ marginTop: 8 }}>{deadlinesMsg}</div>
+                          )}
+                          {deadlinesErr && (
+                            <div className="notice" style={{ marginTop: 8 }}>{deadlinesErr}</div>
+                          )}
+                        </div>
+
+                        <div style={{ marginTop: 12, fontWeight: 700 }}>Métricas clave</div>
+
+                        <div className="form-row" style={{ marginTop: 8 }}>
+                          <div style={fieldStyle}>
+                            <div style={labelStyle}>Días a decisión</div>
+                            <span className={decisionBadgeClass}>{decisionLabel}</span>
+                          </div>
+                          <div style={fieldStyle}>
+                            <label htmlFor="metric-fiscal" style={labelStyle}>Inversión de capital fiscal (MXN)</label>
+                            <input
+                              id="metric-fiscal"
+                              className="input"
+                              type="number"
+                              min="0"
+                              step="any"
+                              value={metrics.fiscalCapitalInvestment ?? ''}
+                              onChange={e => updateMetric('fiscalCapitalInvestment', e.target.value)}
+                            />
+                          </div>
+                        </div>
+
+                        <div className="form-row" style={{ marginTop: 8 }}>
+                          <div style={fieldStyle}>
+                            <label htmlFor="metric-project-amount" style={labelStyle}>Utilidad de proyecto (MXN)</label>
+                            <input
+                              id="metric-project-amount"
+                              className="input"
+                              type="number"
+                              min="0"
+                              step="any"
+                              value={projectProfitability.amount ?? ''}
+                              onChange={e => updateMetric('projectProfitability', current => ({ ...(current || {}), amount: e.target.value }))}
+                            />
+                          </div>
+                          <div style={fieldStyle}>
+                            <label htmlFor="metric-project-years" style={labelStyle}>Horizonte (años)</label>
+                            <input
+                              id="metric-project-years"
+                              className="input"
+                              type="number"
+                              min="0"
+                              value={projectProfitability.years ?? ''}
+                              onChange={e => updateMetric('projectProfitability', current => ({ ...(current || {}), years: e.target.value }))}
+                            />
+                          </div>
+                        </div>
+
+                        <div className="form-row" style={{ marginTop: 8 }}>
+                          <div style={fieldStyle}>
+                            <label htmlFor="metric-portfolio-type" style={labelStyle}>Portafolio</label>
+                            <select
+                              id="metric-portfolio-type"
+                              className="select"
+                              value={portfolio.type || ''}
+                              onChange={e => handlePortfolioTypeChange(e.target.value)}
+                            >
+                              <option value="">Selecciona una opción</option>
+                              {PORTFOLIO_OPTIONS.map(opt => (
+                                <option key={opt.value} value={opt.value}>{opt.label}</option>
+                              ))}
+                            </select>
+                          </div>
+                        </div>
+
+                        {isPortfolioMix && (
+                          <div style={{ marginTop: 8 }}>
+                            <div className="form-row">
+                              {MIX_FIELDS.map(field => (
+                                <div key={field.key} style={mixFieldStyle}>
+                                  <label htmlFor={`metric-portfolio-${field.key}`} style={labelStyle}>{field.label} (%)</label>
+                                  <input
+                                    id={`metric-portfolio-${field.key}`}
+                                    className="input"
+                                    type="number"
+                                    min="0"
+                                    max="100"
+                                    step="any"
+                                    value={mixValues[field.key] ?? ''}
+                                    onChange={e => handleMixChange(field.key, e.target.value)}
+                                  />
+                                </div>
+                              ))}
+                            </div>
+                            <div style={{ marginTop: 4, fontSize: 12, color: 'var(--muted)' }}>Suma: {mixTotal}%</div>
+                          </div>
+                        )}
+
+                        <button className="btn" type="submit" style={{ marginTop: 12 }}>Guardar</button>
+                      </form>
+                      {msg && <div className="notice" style={{marginTop:8}}>{msg}</div>}
+                      {err && <div className="notice" style={{marginTop:8}}>{err}</div>}
                     </div>
-                    <div style={fieldStyle}>
-                      <label htmlFor={`project-${index}-loi`} style={labelStyle}>Enlace a LOI</label>
-                      <input
-                        id={`project-${index}-loi`}
-                        className="input"
-                        type="url"
-                        placeholder="https://"
-                        value={project.loi_template}
-                        onChange={e => updateProjectField(index, 'loi_template', e.target.value)}
-                      />
+                    <div className="card" style={{marginTop:12}} ref={docsCardRef}>
+                      <div className="h2">Documentos por inversionista</div>
+                      <form
+                        onSubmit={handleDocSlugSubmit}
+                        className="form-row"
+                        style={{ marginTop: 8, alignItems: 'flex-end', gap: 12 }}
+                      >
+                        <div style={{ ...fieldStyle, minWidth: 200 }}>
+                          <label htmlFor="docs-slug" style={labelStyle}>Slug del inversionista</label>
+                          <input
+                            id="docs-slug"
+                            className="input"
+                            value={docSlugInput}
+                            onChange={e => setDocSlugInput(e.target.value)}
+                            placeholder="slug"
+                          />
+                        </div>
+                        <div style={{ ...fieldStyle, minWidth: 200 }}>
+                          <label htmlFor="docs-category" style={labelStyle}>Categoría</label>
+                          <select
+                            id="docs-category"
+                            className="select"
+                            value={docCategory}
+                            onChange={e => { setDocCategory(e.target.value); setDocsNotice(null); setDocsError(null) }}
+                          >
+                            {DOCUMENT_SECTIONS_ORDER.map(cat => (
+                              <option key={cat} value={cat}>{cat}</option>
+                            ))}
+                          </select>
+                        </div>
+                        <button className="btn" type="submit" disabled={docsLoading || docsWorking}>Ver carpeta</button>
+                        <button
+                          className="btn secondary"
+                          type="button"
+                          onClick={() => { setDocsNotice(null); setDocsError(null); loadDocs() }}
+                          disabled={docsLoading || docsWorking}
+                        >
+                          Actualizar
+                        </button>
+                      </form>
+                      <div style={{ marginTop: 8, fontSize: 13, color: 'var(--muted)' }}>
+                        Gestionando: <code>{docCategory}/{effectiveDocSlug}</code>
+                      </div>
+                      <form onSubmit={handleDocUpload} className="form-row" style={{ marginTop: 12 }} aria-busy={docsWorking}>
+                        <input name="file" type="file" className="input" disabled={docsWorking} ref={docsUploadInputRef} />
+                        <button className="btn" type="submit" disabled={docsWorking}>
+                          {docsWorking ? 'Subiendo…' : 'Subir'}
+                        </button>
+                        <span className="notice">Los archivos se guardan en GitHub.</span>
+                      </form>
+                      {docsError && <div className="notice" style={{marginTop:8}}>{docsError}</div>}
+                      {docsNotice && <div className="notice" style={{marginTop:8}}>{docsNotice}</div>}
+                      {docsWorking && !docsLoading && <div style={{marginTop:8, color:'var(--muted)'}}>Procesando...</div>}
+                      {docsLoading && <div style={{marginTop:8, color:'var(--muted)'}}>Cargando documentos...</div>}
+                      <table className="table" style={{ marginTop: 12 }} ref={docsTableRef}>
+                        <thead>
+                          <tr>
+                            <th>Archivo</th>
+                            <th>Tamaño</th>
+                            <th></th>
+                          </tr>
+                        </thead>
+                        <tbody>
+                          {docList.map(file => (
+                            <tr key={file.path}>
+                              <td>{file.name}</td>
+                              <td>{(file.size / 1024).toFixed(1)} KB</td>
+                              <td style={{ display: 'flex', gap: 8, justifyContent: 'flex-end' }}>
+                                <a
+                                  className="btn secondary"
+                                  href={api.downloadDocPath(file.path)}
+                                  target="_blank"
+                                  rel="noopener noreferrer"
+                                >
+                                  Descargar
+                                </a>
+                                <button
+                                  type="button"
+                                  className="btn secondary"
+                                  onClick={() => handleDocDelete(file)}
+                                  disabled={docsWorking}
+                                >
+                                  Eliminar
+                                </button>
+                              </td>
+                            </tr>
+                          ))}
+                          {!docList.length && !docsLoading && (
+                            <tr>
+                              <td colSpan="3">No hay documentos en esta carpeta.</td>
+                            </tr>
+                          )}
+                        </tbody>
+                      </table>
                     </div>
-                  </div>
-                </div>
-              ))}
-              {!projectList.length && (
-                <div style={{marginTop:12, color:'var(--muted)'}}>No hay proyectos cargados. Usa "Agregar proyecto".</div>
-              )}
-              <div className="row" style={{marginTop:12, gap:8}}>
-                <button type="button" className="btn secondary" onClick={addProject}>Agregar proyecto</button>
-                <button type="submit" className="btn" disabled={projectSaving}>
-                  {projectSaving ? 'Guardando...' : 'Guardar proyectos'}
-                </button>
-              </div>
-            </form>
-          )}
-          {projectSaveMsg && <div className="notice" style={{marginTop:8}}>{projectSaveMsg}</div>}
-          {projectSaveErr && <div className="notice" style={{marginTop:8}}>{projectSaveErr}</div>}
-        </div>
-        <div className="card" style={{marginTop:12}}>
-          <div className="h2">Notas</div>
-          <ul>
-            <li>Este panel hace commits a GitHub (mismo repo) en <code>data/investors/&lt;slug&gt;.json</code>.</li>
-            <li>Netlify vuelve a construir el sitio y los cambios quedan visibles al instante.</li>
-          </ul>
-        </div>
+                    {docRenamePrompt && (
+                      <div style={modalBackdropStyle} role="dialog" aria-modal="true" aria-labelledby="doc-rename-title">
+                        <div style={modalCardStyle}>
+                          <div className="h2" id="doc-rename-title" style={{ marginTop: 0 }}>Archivo duplicado</div>
+                          <p style={{ marginTop: 8, color: 'var(--muted)', fontSize: 14 }}>
+                            Ya existe un archivo con ese nombre. ¿Quieres subirlo con un sufijo automático?
+                          </p>
+                          <p style={{ fontSize: 13 }}>
+                            <code>{docRenamePrompt.path}</code>
+                          </p>
+                          <div style={modalButtonRowStyle}>
+                            <button
+                              type="button"
+                              className="btn secondary"
+                              onClick={handleCancelDocRename}
+                              disabled={docsWorking}
+                            >
+                              Cancelar
+                            </button>
+                            <button
+                              type="button"
+                              className="btn"
+                              onClick={handleConfirmDocRename}
+                              disabled={docsWorking}
+                              aria-busy={docsWorking}
+                            >
+                              {docsWorking ? 'Subiendo…' : 'Renombrar y subir'}
+                            </button>
+                          </div>
+                        </div>
+                      </div>
+                    )}
+                    <div className="card" style={{marginTop:12}}>
+                      <div className="h2">Gestionar proyectos activos</div>
+                      <p style={{ margin: 0, color: 'var(--muted)', fontSize: 14 }}>Actualiza la lista que aparece en la sección de Proyectos.</p>
+                      {projectLoadErr && <div className="notice" style={{marginTop:8}}>{projectLoadErr}</div>}
+                      {projectsLoading ? (
+                        <div style={{marginTop:8, color:'var(--muted)'}}>Cargando proyectos...</div>
+                      ) : (
+                        <form onSubmit={onSaveProjects}>
+                          {projectList.map((project, index) => (
+                            <div key={project.id || index} style={projectBoxStyle}>
+                              <div className="row" style={{justifyContent:'space-between'}}>
+                                <div style={{fontWeight:700}}>{project.name || project.id || `Proyecto ${index + 1}`}</div>
+                                <button
+                                  type="button"
+                                  className="btn secondary"
+                                  style={{padding:'6px 12px', fontSize:12}}
+                                  onClick={() => removeProject(index)}
+                                >
+                                  Eliminar
+                                </button>
+                              </div>
+                              <div className="form-row" style={{marginTop:8}}>
+                                <div style={fieldStyle}>
+                                  <label htmlFor={`project-${index}-id`} style={labelStyle}>ID</label>
+                                  <input
+                                    id={`project-${index}-id`}
+                                    className="input"
+                                    value={project.id}
+                                    onChange={e => updateProjectField(index, 'id', e.target.value)}
+                                  />
+                                </div>
+                                <div style={fieldStyle}>
+                                  <label htmlFor={`project-${index}-name`} style={labelStyle}>Nombre</label>
+                                  <input
+                                    id={`project-${index}-name`}
+                                    className="input"
+                                    value={project.name}
+                                    onChange={e => updateProjectField(index, 'name', e.target.value)}
+                                  />
+                                </div>
+                                <div style={fieldStyle}>
+                                  <label htmlFor={`project-${index}-client`} style={labelStyle}>Cliente</label>
+                                  <input
+                                    id={`project-${index}-client`}
+                                    className="input"
+                                    value={project.client}
+                                    onChange={e => updateProjectField(index, 'client', e.target.value)}
+                                  />
+                                </div>
+                              </div>
+                              <div className="form-row" style={{marginTop:8}}>
+                                <div style={fieldStyle}>
+                                  <label htmlFor={`project-${index}-location`} style={labelStyle}>Ubicación</label>
+                                  <input
+                                    id={`project-${index}-location`}
+                                    className="input"
+                                    value={project.location}
+                                    onChange={e => updateProjectField(index, 'location', e.target.value)}
+                                  />
+                                </div>
+                                <div style={fieldStyle}>
+                                  <label htmlFor={`project-${index}-model`} style={labelStyle}>Modelo</label>
+                                  <input
+                                    id={`project-${index}-model`}
+                                    className="input"
+                                    value={project.model}
+                                    onChange={e => updateProjectField(index, 'model', e.target.value)}
+                                  />
+                                </div>
+                                <div style={fieldStyle}>
+                                  <label htmlFor={`project-${index}-status`} style={labelStyle}>Estado</label>
+                                  <input
+                                    id={`project-${index}-status`}
+                                    className="input"
+                                    value={project.status}
+                                    onChange={e => updateProjectField(index, 'status', e.target.value)}
+                                  />
+                                </div>
+                              </div>
+                              <div className="form-row" style={{marginTop:8}}>
+                                {PROJECT_NUMBER_FIELDS.map(field => (
+                                  <div key={field.key} style={fieldStyle}>
+                                    <label htmlFor={`project-${index}-${field.key}`} style={labelStyle}>{field.label}</label>
+                                    <input
+                                      id={`project-${index}-${field.key}`}
+                                      className="input"
+                                      type="number"
+                                      min="0"
+                                      step="any"
+                                      value={project[field.key] ?? ''}
+                                      onChange={e => updateProjectField(index, field.key, e.target.value)}
+                                    />
+                                  </div>
+                                ))}
+                              </div>
+                              <div className="form-row" style={{marginTop:8}}>
+                                <div style={fieldStyle}>
+                                  <label htmlFor={`project-${index}-termMonths`} style={labelStyle}>Plazo (meses)</label>
+                                  <input
+                                    id={`project-${index}-termMonths`}
+                                    className="input"
+                                    type="number"
+                                    min="0"
+                                    step="1"
+                                    value={project.termMonths ?? 0}
+                                    onChange={e => updateProjectField(index, 'termMonths', e.target.value)}
+                                  />
+                                </div>
+                                <div style={fieldStyle}>
+                                  <label htmlFor={`project-${index}-empresa`} style={labelStyle}>Empresa</label>
+                                  <input
+                                    id={`project-${index}-empresa`}
+                                    className="input"
+                                    type="text"
+                                    value={project.empresa ?? ''}
+                                    onChange={e => updateProjectField(index, 'empresa', e.target.value)}
+                                    placeholder="Razón social / filial"
+                                  />
+                                </div>
+                                <div style={fieldStyle}>
+                                  <label htmlFor={`project-${index}-imageUrl`} style={labelStyle}>Imagen (URL)</label>
+                                  <input
+                                    id={`project-${index}-imageUrl`}
+                                    className="input"
+                                    type="url"
+                                    placeholder="https://..."
+                                    value={project.imageUrl ?? ''}
+                                    onChange={e => updateProjectField(index, 'imageUrl', e.target.value)}
+                                  />
+                                  {project.imageUrl && /^https?:\/\//i.test(project.imageUrl) && (
+                                    <div style={{ marginTop: 8 }}>
+                                      <img
+                                        src={project.imageUrl}
+                                        alt={project.name || project.id || 'Proyecto'}
+                                        style={{ maxWidth: 160, borderRadius: 8 }}
+                                      />
+                                    </div>
+                                  )}
+                                </div>
+                              </div>
+                              <div className="form-row" style={{marginTop:8}}>
+                                <div style={{ ...fieldStyle, minWidth: 260 }}>
+                                  <label htmlFor={`project-${index}-notes`} style={labelStyle}>Notas</label>
+                                  <textarea
+                                    id={`project-${index}-notes`}
+                                    className="input"
+                                    style={noteAreaStyle}
+                                    value={project.notes}
+                                    onChange={e => updateProjectField(index, 'notes', e.target.value)}
+                                  />
+                                </div>
+                                <div style={fieldStyle}>
+                                  <label htmlFor={`project-${index}-loi`} style={labelStyle}>Enlace a LOI</label>
+                                  <input
+                                    id={`project-${index}-loi`}
+                                    className="input"
+                                    type="url"
+                                    placeholder="https://"
+                                    value={project.loi_template}
+                                    onChange={e => updateProjectField(index, 'loi_template', e.target.value)}
+                                  />
+                                </div>
+                              </div>
+                            </div>
+                          ))}
+                          {!projectList.length && (
+                            <div style={{marginTop:12, color:'var(--muted)'}}>No hay proyectos cargados. Usa "Agregar proyecto".</div>
+                          )}
+                          <div className="row" style={{marginTop:12, gap:8}}>
+                            <button type="button" className="btn secondary" onClick={addProject}>Agregar proyecto</button>
+                            <button type="submit" className="btn" disabled={projectSaving}>
+                              {projectSaving ? 'Guardando...' : 'Guardar proyectos'}
+                            </button>
+                          </div>
+                        </form>
+                      )}
+                      {projectSaveMsg && <div className="notice" style={{marginTop:8}}>{projectSaveMsg}</div>}
+                      {projectSaveErr && <div className="notice" style={{marginTop:8}}>{projectSaveErr}</div>}
+                    </div>
+                    <div className="card" style={{marginTop:12}}>
+                      <div className="h2">Notas</div>
+                      <ul>
+                        <li>Este panel hace commits a GitHub (mismo repo) en <code>data/investors/&lt;slug&gt;.json</code>.</li>
+                        <li>Netlify vuelve a construir el sitio y los cambios quedan visibles al instante.</li>
+                      </ul>
+                    </div>
+            </div>
+          </div>
+        </main>
       </div>
       {panelModal && (
         <div style={modalBackdropStyle}>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    }
+  }
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,9 @@
 import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
 import { fileURLToPath, URL } from 'node:url'
 
 export default defineConfig({
+  plugins: [react()],
   server: { port: 5173 },
   build: { outDir: 'dist' },
   resolve: {


### PR DESCRIPTION
## Summary
- configure Vite with a TypeScript-aware `@` alias and add the React plugin so new aliased imports resolve in build tools
- add a reusable error boundary plus global error listeners and wrap the app/admin route to surface failures instead of a blank screen
- harden deadline helpers/components and refresh the admin layout so invalid data no longer crashes the UI and the panel always scrolls

## Testing
- `npm run build` *(fails: missing @vitejs/plugin-react in the offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d994e5e8a0832d9c2673491550a93b