### PR TITLE
Ensure project document links use slugged folders

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ VITE_PUBLIC_INVESTOR_ID=femsa
 - **Descargar:** `get-doc` entrega el archivo desde GitHub siempre que pertenezca al slug público configurado.
 - **Auditoría:** el historial de cambios queda en GitHub (quién y qué).
 
+Cada proyecto activo define su propio `slug` en `data/projects.json`; los botones “Ver documentos” en `/projects` generan enlaces `/#/documents?investor=<slug>` que cargan exclusivamente los archivos de esa carpeta (`<Categoría>/<slug>/`). Así se evita mezclar documentos entre proyectos.
+
 > Sugerencia: estructura de carpetas en el repo de docs
 >
 > ```

--- a/data/projects.json
+++ b/data/projects.json
@@ -8,7 +8,8 @@
     "power_kwp": 1967,
     "energy_mwh": 2763,
     "co2_tons": 1208,
-    "termMonths": 0
+    "termMonths": 0,
+    "slug": "celocan-celoplaya"
   },
   {
     "id": "proj-danone-multi-sitios",
@@ -20,7 +21,8 @@
     "energy_mwh": 1184.34,
     "co2_tons": 519,
     "termMonths": 0,
-    "notes": "Conjunto de propuestas PPA en 8 sitios. Promedio de ahorro > 45%."
+    "notes": "Conjunto de propuestas PPA en 8 sitios. Promedio de ahorro > 45%.",
+    "slug": "danone-multi-sitios"
   },
   {
     "id": "proj-grupo-zorro-abarrotero",
@@ -32,7 +34,8 @@
     "energy_mwh": 4028.6,
     "co2_tons": 1761.3,
     "termMonths": 0,
-    "empresa": "Grupo Zorro Abarrotero"
+    "empresa": "Grupo Zorro Abarrotero",
+    "slug": "grupo-zorro-abarrotero"
   },
   {
     "id": "proj-stepan",
@@ -44,7 +47,8 @@
     "energy_mwh": 1859.8,
     "co2_tons": 813.1,
     "termMonths": 0,
-    "empresa": "Stepan"
+    "empresa": "Stepan",
+    "slug": "stepan"
   },
   {
     "id": "proj-techo-celocan",
@@ -56,7 +60,8 @@
     "energy_mwh": 168.6,
     "co2_tons": 73.7,
     "termMonths": 0,
-    "empresa": "CFE"
+    "empresa": "CFE",
+    "slug": "techo-celocan"
   },
   {
     "id": "proj-techo-celoplaya",
@@ -68,7 +73,8 @@
     "energy_mwh": 2594.4,
     "co2_tons": 1134.3,
     "termMonths": 0,
-    "empresa": "CFE"
+    "empresa": "CFE",
+    "slug": "techo-celoplaya"
   },
   {
     "id": "proj-carretera-costera-golfo",
@@ -80,7 +86,8 @@
     "energy_mwh": 934.1,
     "co2_tons": 408.4,
     "termMonths": 0,
-    "empresa": "CFE"
+    "empresa": "CFE",
+    "slug": "carretera-costera-golfo"
   },
   {
     "id": "proj-techo-ayuntamiento-cancun",
@@ -92,7 +99,8 @@
     "energy_mwh": 550.6,
     "co2_tons": 240.7,
     "termMonths": 0,
-    "empresa": "CFE"
+    "empresa": "CFE",
+    "slug": "techo-ayuntamiento-cancun"
   },
   {
     "id": "proj-techo-teatro-cancun",
@@ -104,7 +112,8 @@
     "energy_mwh": 289.4,
     "co2_tons": 126.5,
     "termMonths": 0,
-    "empresa": "CFE"
+    "empresa": "CFE",
+    "slug": "techo-teatro-cancun"
   },
   {
     "id": "proj-terreno-mina-paa-mul",
@@ -116,7 +125,8 @@
     "energy_mwh": 4214,
     "co2_tons": 1843.4,
     "termMonths": 0,
-    "empresa": "CFE"
+    "empresa": "CFE",
+    "slug": "terreno-mina-paa-mul"
   },
   {
     "id": "proj-20-noviembre",
@@ -128,6 +138,7 @@
     "energy_mwh": 4916.4,
     "co2_tons": 2149.5,
     "termMonths": 0,
-    "empresa": "CFE"
+    "empresa": "CFE",
+    "slug": "20-noviembre"
   }
 ]

--- a/netlify/functions/save-projects.js
+++ b/netlify/functions/save-projects.js
@@ -33,6 +33,14 @@ function normalizeProject(project, index){
   const working = { ...project, __index: index + 1 }
   const id = trimString(working.id)
   if (!id) throw new Error(`Proyecto ${index + 1} requiere un id`)
+  const slugRaw = trimString(working.slug)
+  if (!slugRaw){
+    throw new Error(`Proyecto ${id} requiere un slug`)
+  }
+  const slug = slugRaw.toLowerCase()
+  if (!/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(slug)){
+    throw new Error(`Proyecto ${id} tiene slug inválido`)
+  }
   const name = trimString(working.name)
   if (!name) throw new Error(`Proyecto ${id} requiere nombre`)
   const client = trimString(working.client)
@@ -45,7 +53,7 @@ function normalizeProject(project, index){
     throw new Error(`Proyecto ${id} tiene Imagen (URL) inválida`)
   }
 
-  const normalized = { id, name, status }
+  const normalized = { id, slug, name, status }
 
   if (client) normalized.client = client
   if (location) normalized.location = location
@@ -86,11 +94,16 @@ export async function handler(event){
     const normalized = list.map((item, index) => normalizeProject(item, index))
 
     const ids = new Set()
+    const slugs = new Set()
     for (const project of normalized){
       if (ids.has(project.id)){
         return text(400, `ID duplicado: ${project.id}`)
       }
       ids.add(project.id)
+      if (slugs.has(project.slug)){
+        return text(400, `Slug duplicado: ${project.slug}`)
+      }
+      slugs.add(project.slug)
     }
 
     const repo = repoEnv('CONTENT_REPO', '')

--- a/src/components/ProjectCard.jsx
+++ b/src/components/ProjectCard.jsx
@@ -1,10 +1,10 @@
 import React from 'react'
-import { useLocation } from 'react-router-dom'
 
 export default function ProjectCard({ p }){
-  const location = useLocation()
-  const search = location.search
-  const documentsHref = `#/documents${search || ''}`
+  const slug = (p.slug || '').trim()
+  const documentsHref = slug
+    ? `/#/documents?investor=${encodeURIComponent(slug)}`
+    : '#/documents'
 
   const metaParts = [p.client, p.location].filter(Boolean)
   const formatMetric = (value, unit) => {


### PR DESCRIPTION
## Summary
- add a slug to every active project and document how each card links to its own document folder
- validate and persist project slugs in the save-projects function so each slug stays unique
- update the project card button to build /#/documents?investor=<slug> links for per-project document views

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd52416b74832daa279cdf76b45bdc