### PR TITLE
fix(projects): unify id as slug and remove extra validation FIX 

### DIFF
--- a/data/projects.json
+++ b/data/projects.json
@@ -8,8 +8,7 @@
     "power_kwp": 1967,
     "energy_mwh": 2763,
     "co2_tons": 1208,
-    "termMonths": 0,
-    "slug": "celocan-celoplaya"
+    "termMonths": 0
   },
   {
     "id": "proj-danone-multi-sitios",
@@ -21,8 +20,7 @@
     "energy_mwh": 1184.34,
     "co2_tons": 519,
     "termMonths": 0,
-    "notes": "Conjunto de propuestas PPA en 8 sitios. Promedio de ahorro > 45%.",
-    "slug": "danone-multi-sitios"
+    "notes": "Conjunto de propuestas PPA en 8 sitios. Promedio de ahorro > 45%."
   },
   {
     "id": "proj-grupo-zorro-abarrotero",
@@ -34,8 +32,7 @@
     "energy_mwh": 4028.6,
     "co2_tons": 1761.3,
     "termMonths": 0,
-    "empresa": "Grupo Zorro Abarrotero",
-    "slug": "grupo-zorro-abarrotero"
+    "empresa": "Grupo Zorro Abarrotero"
   },
   {
     "id": "proj-stepan",
@@ -47,8 +44,7 @@
     "energy_mwh": 1859.8,
     "co2_tons": 813.1,
     "termMonths": 0,
-    "empresa": "Stepan",
-    "slug": "stepan"
+    "empresa": "Stepan"
   },
   {
     "id": "proj-techo-celocan",
@@ -60,8 +56,7 @@
     "energy_mwh": 168.6,
     "co2_tons": 73.7,
     "termMonths": 0,
-    "empresa": "CFE",
-    "slug": "techo-celocan"
+    "empresa": "CFE"
   },
   {
     "id": "proj-techo-celoplaya",
@@ -73,8 +68,7 @@
     "energy_mwh": 2594.4,
     "co2_tons": 1134.3,
     "termMonths": 0,
-    "empresa": "CFE",
-    "slug": "techo-celoplaya"
+    "empresa": "CFE"
   },
   {
     "id": "proj-carretera-costera-golfo",
@@ -86,8 +80,7 @@
     "energy_mwh": 934.1,
     "co2_tons": 408.4,
     "termMonths": 0,
-    "empresa": "CFE",
-    "slug": "carretera-costera-golfo"
+    "empresa": "CFE"
   },
   {
     "id": "proj-techo-ayuntamiento-cancun",
@@ -99,8 +92,7 @@
     "energy_mwh": 550.6,
     "co2_tons": 240.7,
     "termMonths": 0,
-    "empresa": "CFE",
-    "slug": "techo-ayuntamiento-cancun"
+    "empresa": "CFE"
   },
   {
     "id": "proj-techo-teatro-cancun",
@@ -112,8 +104,7 @@
     "energy_mwh": 289.4,
     "co2_tons": 126.5,
     "termMonths": 0,
-    "empresa": "CFE",
-    "slug": "techo-teatro-cancun"
+    "empresa": "CFE"
   },
   {
     "id": "proj-terreno-mina-paa-mul",
@@ -125,8 +116,7 @@
     "energy_mwh": 4214,
     "co2_tons": 1843.4,
     "termMonths": 0,
-    "empresa": "CFE",
-    "slug": "terreno-mina-paa-mul"
+    "empresa": "CFE"
   },
   {
     "id": "proj-20-noviembre",
@@ -138,7 +128,6 @@
     "energy_mwh": 4916.4,
     "co2_tons": 2149.5,
     "termMonths": 0,
-    "empresa": "CFE",
-    "slug": "20-noviembre"
+    "empresa": "CFE"
   }
 ]

--- a/netlify.toml
+++ b/netlify.toml
@@ -9,8 +9,8 @@
   included_files = ["data/**"]
 
 [[redirects]]
-  from = "/i/:slug"
-  to = "/#/?investor=:slug"
+  from = "/i/:id"
+  to = "/#/?investor=:id"
   status = 200
   force = true
 

--- a/netlify/functions/list-docs.js
+++ b/netlify/functions/list-docs.js
@@ -1,7 +1,7 @@
 import { ok, text } from './_lib/utils.mjs'
 import { repoEnv, listDir } from './_lib/github.mjs'
 
-function publicSlug(){
+function publicInvestorId(){
   const raw = typeof process.env.PUBLIC_INVESTOR_SLUG === 'string'
     ? process.env.PUBLIC_INVESTOR_SLUG.trim().toLowerCase()
     : ''
@@ -11,9 +11,10 @@ function publicSlug(){
 export async function handler(event){
   try{
     const category = (event.queryStringParameters && event.queryStringParameters.category) || 'NDA'
-    const slugParam = event.queryStringParameters && event.queryStringParameters.slug
-    const requested = typeof slugParam === 'string' ? slugParam.trim().toLowerCase() : ''
-    const slug = requested || publicSlug()
+    const investorParam = event.queryStringParameters
+      && (event.queryStringParameters.investor ?? event.queryStringParameters.slug)
+    const requested = typeof investorParam === 'string' ? investorParam.trim().toLowerCase() : ''
+    const investorId = requested || publicInvestorId()
 
     const repo = repoEnv('DOCS_REPO', '')
     const branch = process.env.DOCS_BRANCH || 'main'
@@ -22,7 +23,7 @@ export async function handler(event){
       return ok({ files: [] })
     }
 
-    const basePath = `${category}/${slug}`
+    const basePath = `${category}/${investorId}`
     let list = []
     try{
       const items = await listDir(repo, basePath, branch)

--- a/netlify/functions/save-projects.js
+++ b/netlify/functions/save-projects.js
@@ -31,15 +31,11 @@ function normalizeProject(project, index){
   }
 
   const working = { ...project, __index: index + 1 }
-  const id = trimString(working.id)
-  if (!id) throw new Error(`Proyecto ${index + 1} requiere un id`)
-  const slugRaw = trimString(working.slug)
-  if (!slugRaw){
-    throw new Error(`Proyecto ${id} requiere un slug`)
-  }
-  const slug = slugRaw.toLowerCase()
-  if (!/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(slug)){
-    throw new Error(`Proyecto ${id} tiene slug inválido`)
+  const rawId = trimString(working.id)
+  if (!rawId) throw new Error(`Proyecto ${index + 1} requiere un id`)
+  const id = rawId.toLowerCase()
+  if (!/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(id)){
+    throw new Error(`Proyecto ${rawId} tiene id inválido`)
   }
   const name = trimString(working.name)
   if (!name) throw new Error(`Proyecto ${id} requiere nombre`)
@@ -53,7 +49,7 @@ function normalizeProject(project, index){
     throw new Error(`Proyecto ${id} tiene Imagen (URL) inválida`)
   }
 
-  const normalized = { id, slug, name, status }
+  const normalized = { id, name, status }
 
   if (client) normalized.client = client
   if (location) normalized.location = location
@@ -94,16 +90,11 @@ export async function handler(event){
     const normalized = list.map((item, index) => normalizeProject(item, index))
 
     const ids = new Set()
-    const slugs = new Set()
     for (const project of normalized){
       if (ids.has(project.id)){
         return text(400, `ID duplicado: ${project.id}`)
       }
       ids.add(project.id)
-      if (slugs.has(project.slug)){
-        return text(400, `Slug duplicado: ${project.slug}`)
-      }
-      slugs.add(project.slug)
     }
 
     const repo = repoEnv('CONTENT_REPO', '')

--- a/netlify/functions/upload-doc.mjs
+++ b/netlify/functions/upload-doc.mjs
@@ -1,7 +1,7 @@
 import { json, text } from './_lib/utils.mjs'
 import { repoEnv, getFile, putFile } from './_lib/github.mjs'
 
-const publicSlug = () => {
+const publicInvestorId = () => {
   const raw = typeof process.env.PUBLIC_INVESTOR_SLUG === 'string'
     ? process.env.PUBLIC_INVESTOR_SLUG.trim().toLowerCase()
     : ''
@@ -39,15 +39,17 @@ export async function handler(event){
     const category = (body.path || '').toString().trim().replace(/^\/+|\/+$/g, '')
     const fileName = (body.filename || '').toString().trim()
     const contentBase64 = (body.contentBase64 || '').toString().trim()
-    const slugInput = typeof body.slug === 'string' ? body.slug.trim().toLowerCase() : ''
-    const slug = slugInput || publicSlug()
+    const investorInput = typeof body.investor === 'string'
+      ? body.investor.trim().toLowerCase()
+      : (typeof body.slug === 'string' ? body.slug.trim().toLowerCase() : '')
+    const investorId = investorInput || publicInvestorId()
     const strategy = typeof body.strategy === 'string' ? body.strategy : undefined
 
     if (!category || !fileName || !contentBase64){
       return text(400, 'Faltan datos (path, filename, contentBase64)')
     }
 
-    const originalPath = `${category}/${slug}/${fileName}`
+    const originalPath = `${category}/${investorId}/${fileName}`
     let existing = null
     try {
       existing = await getFile(repo, originalPath, branch)
@@ -72,7 +74,7 @@ export async function handler(event){
       const base = dotIndex > -1 ? fileName.slice(0, dotIndex) : fileName
       const ext = dotIndex > -1 ? fileName.slice(dotIndex) : ''
       finalFileName = `${base}_${formatTimestamp()}${ext}`
-      finalPath = `${category}/${slug}/${finalFileName}`
+      finalPath = `${category}/${investorId}/${finalFileName}`
       renamed = true
     }
 
@@ -92,7 +94,7 @@ export async function handler(event){
     }
 
     const commitMessageSuffix = renamed ? ' (auto-rename)' : ''
-    const commitMessage = `docs(${slug}): upload ${category}/${finalFileName}${commitMessageSuffix}`
+    const commitMessage = `docs(${investorId}): upload ${category}/${finalFileName}${commitMessageSuffix}`
 
     await putFile(repo, finalPath, contentBase64, commitMessage, undefined, branch)
 

--- a/src/components/ProjectCard.jsx
+++ b/src/components/ProjectCard.jsx
@@ -1,9 +1,9 @@
 import React from 'react'
 
 export default function ProjectCard({ p }){
-  const slug = (p.slug || '').trim()
-  const documentsHref = slug
-    ? `/#/documents?investor=${encodeURIComponent(slug)}`
+  const investorId = (p.id || '').trim().toLowerCase()
+  const documentsHref = investorId
+    ? `/#/documents?investor=${encodeURIComponent(investorId)}`
     : '#/documents'
 
   const metaParts = [p.client, p.location].filter(Boolean)

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -57,10 +57,10 @@ export const api = {
   downloadDocPath(relPath){
     const normalized = (relPath || '').replace(/^\/+/, '')
     const parts = normalized.split('/').filter(Boolean)
-    const slug = parts.length > 1 ? parts[1] : ''
+    const investorId = parts.length > 1 ? parts[1] : ''
     const params = new URLSearchParams()
     if (normalized) params.set('path', normalized)
-    if (slug) params.set('investor', slug)
+    if (investorId) params.set('investor', investorId)
     const qs = params.toString()
     return `/.netlify/functions/get-doc${qs ? `?${qs}` : ''}`
   },

--- a/src/pages/Documents.jsx
+++ b/src/pages/Documents.jsx
@@ -17,7 +17,7 @@ export default function Documents(){
   const [renamePrompt, setRenamePrompt] = useState(null)
 
   const fetchDocs = useCallback(async (category) => {
-    const res = await api.listDocs({ category, slug: investorId })
+    const res = await api.listDocs({ category, investor: investorId })
     const files = Array.isArray(res?.files) ? res.files : []
     return files
   }, [investorId])
@@ -78,7 +78,7 @@ export default function Documents(){
         path: `${uploadInfo.category}`,
         filename: uploadInfo.filename,
         contentBase64: uploadInfo.base64,
-        slug: uploadInfo.slug,
+        investor: uploadInfo.investor,
         message: uploadInfo.message
       }
       if (options.strategy === 'rename'){
@@ -96,7 +96,7 @@ export default function Documents(){
       return response
     }catch(err){
       if (err?.status === 409 && err?.data?.error === 'FILE_EXISTS' && options.strategy !== 'rename'){
-        const fallbackPath = `${uploadInfo.category}/${uploadInfo.slug}/${uploadInfo.filename}`
+        const fallbackPath = `${uploadInfo.category}/${uploadInfo.investor}/${uploadInfo.filename}`
         setPendingUpload(uploadInfo)
         setRenamePrompt({ path: err.data?.path || fallbackPath, category: uploadInfo.category })
         return null
@@ -129,7 +129,7 @@ export default function Documents(){
           category,
           filename: file.name,
           base64,
-          slug: investorId,
+          investor: investorId,
           message: `Upload ${file.name} from Dealroom UI`,
           form
         })

--- a/src/pages/Updates.jsx
+++ b/src/pages/Updates.jsx
@@ -167,7 +167,7 @@ export default function Updates(){
           for (const investor of investorList){
             if (!active) return
             try{
-              const res = await api.listDocs({ category, slug: investor.slug })
+              const res = await api.listDocs({ category, investor: investor.slug })
               const files = Array.isArray(res?.files) ? res.files : []
               categoryData[investor.slug] = { files, error: null }
             }catch(error){


### PR DESCRIPTION
## Summary
- drop the extra `slug` field from project data and validation, normalising ids when persisting from the admin panel
- update project cards and document workflows to build links and uploads with the project/investor id, keeping compatibility fallbacks for legacy slug calls
- switch serverless document handlers and redirects to read the `investor` id parameter and adjust supporting helpers

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd5e6eeb90832da014e12487afb2be