### PR TITLE
chore(documents): remove public GitHub warning banner

### DIFF
--- a/src/pages/Documents.jsx
+++ b/src/pages/Documents.jsx
@@ -173,11 +173,6 @@ export default function Documents(){
           {loading ? 'Actualizando…' : 'Actualizar'}
         </button>
       </div>
-
-      <div className="card" style={{ marginTop: 12 }}>
-        <span className="notice">Los archivos se guardan en GitHub y se exponen públicamente.</span>
-      </div>
-
       {error && <div className="notice" style={{ marginTop: 12 }}>{error}</div>}
 
       <div style={{ marginTop: 12, display: 'grid', gap: 24 }}>


### PR DESCRIPTION
## Summary
- remove the informational card that warned documents are stored publicly on GitHub from the Documents page

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd6560ea84832daef4b451f7a22d08