### PR TITLE
Enable document downloads from Documents page

### DIFF
--- a/src/pages/Documents.jsx
+++ b/src/pages/Documents.jsx
@@ -208,7 +208,15 @@ export default function Documents(){
                         <td>{d.name}</td>
                         <td>{(d.size / 1024).toFixed(1)} KB</td>
                         <td>
-                          <a className="btn secondary" href={api.downloadDocPath(d.path)}>Descargar</a>
+                          <a
+                            className="btn secondary"
+                            href={api.downloadDocPath(d.path)}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            download={d.name}
+                          >
+                            Descargar
+                          </a>
                         </td>
                       </tr>
                     ))}


### PR DESCRIPTION
## Summary
- ensure document download buttons open in a new tab and include the filename for saving

## Testing
- npm run dev -- --host 0.0.0.0 --port 4173

------
https://chatgpt.com/codex/tasks/task_e_68dd884220c8832d8d5f43ae7427d49b