### PR TITLE
feat: enforce investor isolation for documents

### DIFF
--- a/netlify/functions/get-doc.js
+++ b/netlify/functions/get-doc.js
@@ -1,52 +1,59 @@
 import { text } from './_lib/utils.mjs'
 import { repoEnv, getFile } from './_lib/github.mjs'
 
-function normalizeId(value){
-  return typeof value === 'string' ? value.trim().toLowerCase() : ''
-}
+const SAFE_SEGMENT = /^[a-zA-Z0-9._ -]+$/
 
-function publicInvestorId(){
-  const raw = normalizeId(process.env.PUBLIC_INVESTOR_SLUG)
-  return raw || 'femsa'
-}
+const normalizeForTest = (value) => value
+  .normalize('NFD')
+  .replace(/\p{Diacritic}/gu, '')
 
-function allowedInvestorIdFrom(event){
-  const qp = event?.queryStringParameters || {}
-  const requested = normalizeId(qp.investor ?? qp.slug)
-  return requested || publicInvestorId()
+const sanitizeSegment = (value, label, { lower = false } = {}) => {
+  const raw = typeof value === 'string' ? value.trim() : ''
+  if (!raw) throw text(400, `${label} requerido`)
+  if (!SAFE_SEGMENT.test(normalizeForTest(raw))){
+    throw text(400, `${label} inválido`)
+  }
+  return lower ? raw.toLowerCase() : raw
 }
 
 export async function handler(event){
   try{
-    const repo = repoEnv('DOCS_REPO', '')
-    const branch = process.env.DOCS_BRANCH || 'main'
+    if (event.httpMethod && event.httpMethod !== 'GET'){
+      return text(405, 'Method not allowed')
+    }
+
+    const repo = repoEnv('DOCS_REPO', '').trim()
+    const branch = (process.env.DOCS_BRANCH || 'main').trim()
+    if (!repo || !branch || !process.env.GITHUB_TOKEN){
+      return text(500, 'DOCS_REPO/DOCS_BRANCH/GITHUB_TOKEN no configurados')
+    }
+
     const params = event.queryStringParameters || {}
-    const relPathRaw = params.path || ''
+    const relPathRaw = typeof params.path === 'string' ? params.path.trim() : ''
     if (!relPathRaw) return text(400, 'Falta path')
+
+    const investorParam = sanitizeSegment(params.investor ?? params.slug, 'investor', { lower: true })
 
     const normalizedPath = relPathRaw.replace(/^\/+/, '')
     if (normalizedPath.includes('..')) return text(400, 'Ruta inválida')
 
-    const pathParts = normalizedPath.split('/').filter(Boolean)
-    if (pathParts.length < 3) return text(400, 'Ruta inválida')
+    const segments = normalizedPath.split('/').filter(Boolean)
+    if (segments.length !== 3) return text(400, 'Ruta inválida')
 
-    const [category, investorSegment, ...restParts] = pathParts
-    const allowedInvestorId = allowedInvestorIdFrom(event)
-    if (!category || !investorSegment || restParts.length === 0) return text(400, 'Ruta inválida')
+    const category = sanitizeSegment(segments[0], 'category')
+    const investorSegment = sanitizeSegment(segments[1], 'investor', { lower: true })
+    const filename = sanitizeSegment(segments[2], 'filename')
 
-    if (normalizeId(investorSegment) !== allowedInvestorId){
+    if (investorSegment !== investorParam){
       return text(404, 'Documento no encontrado o acceso denegado.')
     }
 
-    if (!repo || !process.env.GITHUB_TOKEN) return text(500, 'DOCS_REPO/GITHUB_TOKEN no configurados')
-
-    const repoPath = [category, allowedInvestorId, ...restParts].join('/')
+    const repoPath = `${category}/${investorSegment}/${filename}`
     const file = await getFile(repo, repoPath, branch)
     const encoding = typeof file.encoding === 'string' ? file.encoding.toLowerCase() : 'base64'
     const buff = encoding === 'base64'
       ? Buffer.from(file.content || '', 'base64')
       : Buffer.from(file.content || '', 'utf-8')
-    const filename = restParts[restParts.length - 1] || file.name
 
     return {
       statusCode: 200,

--- a/netlify/functions/update-investor.mjs
+++ b/netlify/functions/update-investor.mjs
@@ -21,7 +21,7 @@ export async function handler(event){
     }
 
     const body = JSON.parse(event.body || '{}')
-    const slug = typeof body.slug === 'string' ? body.slug.trim() : ''
+    const slug = typeof body.slug === 'string' ? body.slug.trim().toLowerCase() : ''
     if (!slug){
       return json(400, { ok: false, error: "Missing required field 'slug'" })
     }
@@ -65,8 +65,24 @@ export async function handler(event){
       }
     }
 
+    const updates = {}
+    for (const [key, value] of Object.entries(body)){
+      if (key === 'slug' || key === 'deadlines' || key === 'id') continue
+      if (key === 'name' && typeof value === 'string'){
+        updates.name = value.trim()
+        continue
+      }
+      if (key === 'status' && typeof value === 'string'){
+        updates.status = value.trim()
+        continue
+      }
+      updates[key] = value
+    }
+
     const updatedInvestor = {
       ...current,
+      ...updates,
+      id: slug,
       deadlines: mergedDeadlines,
       updatedAt: new Date().toISOString()
     }

--- a/src/pages/Documents.jsx
+++ b/src/pages/Documents.jsx
@@ -19,6 +19,7 @@ export default function Documents(){
   const [deletingFile, setDeletingFile] = useState(null)
 
   const fetchDocs = useCallback(async (category) => {
+    if (!investorId) return []
     const res = await api.listDocs({ category, investor: investorId })
     const files = Array.isArray(res?.files) ? res.files : []
     return files


### PR DESCRIPTION
## Summary
- scope document listing, download, upload, and deletion functions to category/investor folders with strict segment validation
- wire the documents UI to use investor-specific APIs for listing, uploading, and deleting files and refresh views after changes
- update investor services and update handler so the admin keeps existing deadline logic while allowing name and status edits

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dddb12adac832db4cb5fb8cb337a3d