### PR TITLE
chore(documents): remove public GitHub notice banner from Documents page

### DIFF
--- a/src/pages/Documents.jsx
+++ b/src/pages/Documents.jsx
@@ -173,11 +173,6 @@ export default function Documents(){
           {loading ? 'Actualizando…' : 'Actualizar'}
         </button>
       </div>
-
-      <div className="card" style={{ marginTop: 12 }}>
-        <span className="notice">Los archivos se guardan en GitHub y se exponen públicamente.</span>
-      </div>
-
       {error && <div className="notice" style={{ marginTop: 12 }}>{error}</div>}
 
       <div style={{ marginTop: 12, display: 'grid', gap: 24 }}>


### PR DESCRIPTION
## Summary
- remove the public GitHub notice card from the Documents page
- keep the document library layout intact without the banner spacing

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68deb01293c8832da418b1d543c9f691