### PR TITLE
Fix document base64 handling for uploads and downloads

### DIFF
--- a/netlify/functions/get-doc.mjs
+++ b/netlify/functions/get-doc.mjs
@@ -1,0 +1,86 @@
+// netlify/functions/get-doc.mjs
+import { Octokit } from "octokit";
+
+function getEnv(name, required = true) {
+  const val = process.env[name];
+  if (required && (!val || !val.trim())) {
+    throw new Error(`Missing env ${name}`);
+  }
+  return val;
+}
+
+function sanitizeSegment(s) {
+  return String(s || "").replace(/[^A-Za-z0-9._ -]/g, "").trim();
+}
+
+function ensureSlugAllowed(inputSlug) {
+  const publicSlug = process.env.PUBLIC_INVESTOR_SLUG;
+  if (publicSlug && publicSlug.trim()) {
+    if (inputSlug !== publicSlug) {
+      throw new Error(`Slug not allowed: ${inputSlug}`);
+    }
+    return publicSlug;
+  }
+  return inputSlug;
+}
+
+function guessContentType(filename) {
+  const f = filename.toLowerCase();
+  if (f.endsWith(".pdf")) return "application/pdf";
+  if (f.endsWith(".docx")) return "application/vnd.openxmlformats-officedocument.wordprocessingml.document";
+  if (f.endsWith(".xlsx")) return "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
+  if (f.endsWith(".csv")) return "text/csv";
+  if (f.endsWith(".png")) return "image/png";
+  if (f.endsWith(".jpg") || f.endsWith(".jpeg")) return "image/jpeg";
+  return "application/octet-stream";
+}
+
+export async function handler(event) {
+  if (event.httpMethod !== "GET") {
+    return { statusCode: 405, body: "Method Not Allowed" };
+  }
+
+  try {
+    const params = event.queryStringParameters || {};
+    const category = sanitizeSegment(params.category);
+    const slug = ensureSlugAllowed(sanitizeSegment(params.slug));
+    const filename = sanitizeSegment(params.filename);
+
+    if (!category || !slug || !filename) {
+      return { statusCode: 400, body: "Missing category/slug/filename" };
+    }
+
+    const path = `${category}/${slug}/${filename}`;
+
+    const DOCS_REPO = getEnv("DOCS_REPO");
+    const DOCS_BRANCH = getEnv("DOCS_BRANCH");
+    const GITHUB_TOKEN = getEnv("GITHUB_TOKEN");
+
+    const octokit = new Octokit({ auth: GITHUB_TOKEN });
+    const [owner, repo] = DOCS_REPO.split("/");
+
+    // Traer contenido en base64 desde GitHub
+    const { data } = await octokit.repos.getContent({ owner, repo, path, ref: DOCS_BRANCH });
+    if (Array.isArray(data) || !data.content) {
+      return { statusCode: 404, body: "File not found or invalid type" };
+    }
+
+    // data.content viene en base64 según GitHub
+    const base64 = data.content.replace(/\n/g, "");
+    const contentType = guessContentType(filename);
+
+    return {
+      statusCode: 200,
+      headers: {
+        "Content-Type": contentType,
+        "Content-Disposition": `attachment; filename="${filename}"`,
+        // Importante para Netlify: estamos devolviendo base64
+        "Cache-Control": "no-store",
+      },
+      body: base64,
+      isBase64Encoded: true,
+    };
+  } catch (err) {
+    return { statusCode: 500, body: `get-doc error: ${err.message}` };
+  }
+}


### PR DESCRIPTION
## Summary
- reimplement the upload-doc Netlify function to validate inputs, enforce slug restrictions, and upload files via Octokit with proper base64 handling
- rewrite the get-doc Netlify function to fetch repository content with Octokit, enforce slug/category checks, and return correctly encoded downloads

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68deca4b4b04832d862f12be860e2216