### PR TITLE
fix(functions): restore get-doc behavior with Blobs API for >1MB and any filetype

### DIFF
--- a/netlify/functions/get-doc.mjs
+++ b/netlify/functions/get-doc.mjs
@@ -16,7 +16,9 @@ function getEnv(name, required = true) {
 }
 
 function sanitizeSegment(s) {
-  return String(s || "").replace(/[^A-Za-z0-9._ -]/g, "").trim();
+  return String(s || "")
+    .replace(/[^A-Za-z0-9._ \-()]/g, "")
+    .trim();
 }
 
 function ensureSlugAllowed(inputSlug) {


### PR DESCRIPTION
## Summary
- allow parentheses in get-doc parameter sanitization to preserve filenames such as "(1).pdf"

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df0371e930832da3da171bdfb62a09