### PR TITLE
feat(alsea): align ALSEA document library with categorized GitHub storage

### DIFF
--- a/netlify/functions/get-doc.mjs
+++ b/netlify/functions/get-doc.mjs
@@ -17,19 +17,20 @@ function getEnv(name, required = true) {
 
 function sanitizeSegment(s) {
   return String(s || "")
-    .replace(/[^A-Za-z0-9._ \-()]/g, "")
+    .normalize("NFKC")
+    .replace(/[^\p{L}\p{N}._() \-]/gu, "")
     .trim();
 }
 
 function ensureSlugAllowed(inputSlug) {
-  const publicSlug = process.env.PUBLIC_INVESTOR_SLUG;
-  if (publicSlug && publicSlug.trim()) {
-    if (inputSlug !== publicSlug) {
+  const envSlug = sanitizeSegment(process.env.PUBLIC_INVESTOR_SLUG || "");
+  if (envSlug) {
+    if (inputSlug.toLowerCase() !== envSlug.toLowerCase()) {
       throw httpError(403, "Slug not allowed");
     }
-    return publicSlug;
+    return envSlug.toLowerCase();
   }
-  return inputSlug;
+  return inputSlug.toLowerCase();
 }
 
 function guessContentType(filename) {

--- a/netlify/functions/list-docs.js
+++ b/netlify/functions/list-docs.js
@@ -1,19 +1,39 @@
 import { ok, text } from './_lib/utils.mjs'
 import { repoEnv, listDir } from './_lib/github.mjs'
 
-function publicSlug(){
-  const raw = typeof process.env.PUBLIC_INVESTOR_SLUG === 'string'
-    ? process.env.PUBLIC_INVESTOR_SLUG.trim().toLowerCase()
-    : ''
-  return raw || 'femsa'
+function sanitizeSegment(value){
+  return String(value || '')
+    .normalize('NFKC')
+    .replace(/[^\p{L}\p{N}._() \-]/gu, '')
+    .trim()
+}
+
+function normalizeLower(value){
+  return sanitizeSegment(value).toLowerCase()
+}
+
+function defaultSlug(){
+  const envSlug = normalizeLower(process.env.PUBLIC_INVESTOR_SLUG || '')
+  return envSlug || 'femsa'
 }
 
 export async function handler(event){
   try{
-    const category = (event.queryStringParameters && event.queryStringParameters.category) || 'NDA'
+    const categoryParam = event.queryStringParameters && event.queryStringParameters.category
     const slugParam = event.queryStringParameters && event.queryStringParameters.slug
-    const requested = typeof slugParam === 'string' ? slugParam.trim().toLowerCase() : ''
-    const slug = requested || publicSlug()
+    const safeCategory = sanitizeSegment(categoryParam) || 'NDA'
+    const requestedSlug = typeof slugParam === 'string' ? sanitizeSegment(slugParam).toLowerCase() : ''
+    const envSlugRaw = sanitizeSegment(process.env.PUBLIC_INVESTOR_SLUG || '')
+    const envSlug = envSlugRaw ? envSlugRaw.toLowerCase() : ''
+
+    let slug = requestedSlug || defaultSlug()
+    if (envSlug){
+      const normalizedEnv = envSlug.toLowerCase()
+      if (requestedSlug && requestedSlug !== normalizedEnv){
+        return text(403, 'Slug not allowed')
+      }
+      slug = envSlug
+    }
 
     const repo = repoEnv('DOCS_REPO', '')
     const branch = process.env.DOCS_BRANCH || 'main'
@@ -22,14 +42,17 @@ export async function handler(event){
       return ok({ files: [] })
     }
 
-    const basePath = `${category}/${slug}`
+    const basePath = `${safeCategory}/${slug}`
     let list = []
     try{
       const items = await listDir(repo, basePath, branch)
       list = items.filter(x => x.type === 'file').map(x => ({
         name: x.name,
+        filename: x.name,
         path: `${basePath}/${x.name}`,
-        size: x.size || 0
+        size: typeof x.size === 'number' ? x.size : 0,
+        sizeBytes: typeof x.size === 'number' ? x.size : 0,
+        sizeKB: typeof x.size === 'number' ? Math.max(0, Math.round(x.size / 1024)) : 0
       }))
     }catch(_){
       list = []

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -64,6 +64,14 @@ export const api = {
     const qs = params.toString()
     return `/.netlify/functions/get-doc${qs ? `?${qs}` : ''}`
   },
+  docDownloadUrl({ category, slug, filename }){
+    const params = new URLSearchParams()
+    if (category) params.set('category', category)
+    if (slug) params.set('slug', slug)
+    if (filename || filename === '') params.set('filename', String(filename))
+    const qs = params.toString()
+    return `/.netlify/functions/get-doc${qs ? `?${qs}` : ''}`
+  },
   async listActivity(){
     return req('/.netlify/functions/list-activity')
   }


### PR DESCRIPTION
## Summary
- route ALSEA document uploads through category/slug filenames and refresh listings by section
- add dedicated ALSEA download URLs and slug handling on the document library UI without affecting other investors
- harden Netlify doc functions with slug sanitization, GitHub blob downloads, and category/slug aware listings

## Testing
- `npm run build` *(fails: vite missing in environment)*
- `npm install` *(fails: npm registry access to octokit is forbidden in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68df09bd3f2c832daaa005786fd73eb9