### PR TITLE
feat: streamline Alsea document storage flow

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -4,14 +4,19 @@
   functions = "netlify/functions"
 
 [functions]
-  directory = "netlify/functions"
   node_bundler = "esbuild"
-  external_node_modules = ["octokit"]
+  external_node_modules = ["octokit", "busboy"]
   included_files = ["data/**"]
 
 [[redirects]]
   from = "/i/:slug"
   to = "/#/?investor=:slug"
+  status = 200
+  force = true
+
+[[redirects]]
+  from = "/api/download"
+  to = "/.netlify/functions/download-file"
   status = 200
   force = true
 

--- a/netlify/functions/download-file.mjs
+++ b/netlify/functions/download-file.mjs
@@ -1,0 +1,83 @@
+// netlify/functions/download-file.mjs
+import { getGithubRawUrl } from "./lib/storage.js";
+
+export const handler = async (event) => {
+  try {
+    if (event.httpMethod !== 'GET') return res(405, 'MethodNotAllowed');
+
+    const q = event.queryStringParameters || {};
+    const slug = (q.slug || '').toLowerCase();
+    const category = (q.category || '').trim();
+    const filename = (q.filename || '').trim();
+    const requestedDisposition = (q.disposition || 'attachment').toLowerCase(); // 'inline' o 'attachment'
+    const disposition = requestedDisposition === 'inline' ? 'inline' : 'attachment';
+
+    if (!slug) return json(400, { ok:false, code:'MissingParam', param:'slug' });
+    if (slug !== 'alsea') return json(403, { ok:false, code:'ForbiddenSlug', msg:'Solo Alsea permitido' });
+    if (!category) return json(400, { ok:false, code:'MissingParam', param:'category' });
+    if (!filename) return json(400, { ok:false, code:'MissingParam', param:'filename' });
+
+    const path = `data/docs/${slug}/${category}/${filename}`;
+    const { downloadUrl, size } = await getGithubRawUrl({ path });
+
+    // Detectar mimetype simple por extensión
+    const ext = filename.split('.').pop()?.toLowerCase();
+    const mimetype = guessMime(ext);
+
+    // Fetch con streaming (Node 18 fetch nativo)
+    const upstream = await fetch(downloadUrl);
+    if (!upstream.ok) return json(404, { ok:false, code:'NotFound' });
+
+    const body = upstream.body; // stream
+
+    return {
+      statusCode: 200,
+      headers: {
+        'Access-Control-Allow-Origin': '*',
+        'Content-Type': mimetype,
+        ...(size ? { 'Content-Length': String(size) } : {}),
+        'Content-Disposition': `${disposition}; filename="${filename}"`
+      },
+      body: await streamToBase64(body),
+      isBase64Encoded: true
+    };
+  } catch (err) {
+    const msg = String(err?.message || err);
+    if (msg === 'NotFound') return json(404, { ok:false, code:'NotFound' });
+    if (msg.startsWith('MissingEnv')) return json(500, { ok:false, code:'MissingEnv', msg });
+    return json(500, { ok:false, code:'DownloadError', msg });
+  }
+};
+
+function guessMime(ext) {
+  if (ext === 'pdf') return 'application/pdf';
+  if (['png','jpg','jpeg','gif','webp'].includes(ext)) return `image/${ext==='jpg'?'jpeg':ext}`;
+  if (ext === 'txt') return 'text/plain';
+  if (ext === 'csv') return 'text/csv';
+  if (ext === 'json') return 'application/json';
+  if (['doc','docx'].includes(ext)) return 'application/vnd.openxmlformats-officedocument.wordprocessingml.document';
+  if (['xls','xlsx'].includes(ext)) return 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet';
+  if (ext === 'zip') return 'application/zip';
+  return 'application/octet-stream';
+}
+
+async function streamToBase64(stream) {
+  const chunks = [];
+  const reader = stream.getReader();
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    chunks.push(value);
+  }
+  const buf = Buffer.concat(chunks);
+  return buf.toString('base64');
+}
+
+function res(statusCode, msg) { return { statusCode, body: msg }; }
+function json(statusCode, obj) {
+  return {
+    statusCode,
+    headers: { 'Access-Control-Allow-Origin': '*', 'Content-Type': 'application/json' },
+    body: JSON.stringify(obj)
+  };
+}

--- a/netlify/functions/lib/storage.js
+++ b/netlify/functions/lib/storage.js
@@ -1,0 +1,43 @@
+// netlify/functions/lib/storage.js
+import { Octokit } from "octokit";
+
+const required = (name, val) => { if (!val) throw new Error(`MissingEnv:${name}`); return val; };
+
+export async function putFileGithub({ path, contentBase64, message, branch, author }) {
+  const token = required('GITHUB_TOKEN', process.env.GITHUB_TOKEN);
+  const repoFull = required('DOCS_REPO', process.env.DOCS_REPO);
+  const branchName = branch || process.env.DOCS_BRANCH || 'main';
+  const [owner, repo] = repoFull.split('/');
+  const octokit = new Octokit({ auth: token });
+
+  // Obtener sha si ya existe
+  let sha;
+  try {
+    const res = await octokit.request('GET /repos/{owner}/{repo}/contents/{path}', { owner, repo, path, ref: branchName });
+    sha = res.data.sha;
+  } catch (_) { /* no existe, continuar */ }
+
+  // Subir (o actualizar)
+  const res = await octokit.request('PUT /repos/{owner}/{repo}/contents/{path}', {
+    owner, repo, path,
+    message: message || `Upload: ${path}`,
+    content: contentBase64, branch: branchName,
+    committer: author || { name: "Dealroom Bot", email: "bot@finsolar.mx" },
+    author: author || { name: "Dealroom Bot", email: "bot@finsolar.mx" },
+    sha
+  });
+  return { ok: true, commitSha: res.data.commit.sha };
+}
+
+export async function getGithubRawUrl({ path, branch }) {
+  const token = required('GITHUB_TOKEN', process.env.GITHUB_TOKEN);
+  const repoFull = required('DOCS_REPO', process.env.DOCS_REPO);
+  const branchName = branch || process.env.DOCS_BRANCH || 'main';
+  const [owner, repo] = repoFull.split('/');
+  const octokit = new Octokit({ auth: token });
+
+  const res = await octokit.request('GET /repos/{owner}/{repo}/contents/{path}', { owner, repo, path, ref: branchName });
+  if (!res?.data?.download_url) throw new Error('NotFound');
+  // Nota: el raw URL permite streaming con fetch nativo en Node 18
+  return { downloadUrl: res.data.download_url, size: res.data.size };
+}

--- a/netlify/functions/list-docs.js
+++ b/netlify/functions/list-docs.js
@@ -42,7 +42,11 @@ export async function handler(event){
       return ok({ files: [] })
     }
 
-    const basePath = `${safeCategory}/${slug}`
+    const effectiveSlug = (slug || '').toLowerCase()
+    const fallbackSlug = effectiveSlug || defaultSlug()
+    const basePath = fallbackSlug === 'alsea'
+      ? `data/docs/${fallbackSlug}/${safeCategory}`
+      : `${safeCategory}/${fallbackSlug}`
     let list = []
     try{
       const items = await listDir(repo, basePath, branch)

--- a/netlify/functions/upload-doc.mjs
+++ b/netlify/functions/upload-doc.mjs
@@ -1,248 +1,66 @@
 // netlify/functions/upload-doc.mjs
-import { Buffer } from "node:buffer";
+import { putFileGithub } from "./lib/storage.js";
+import Busboy from "busboy";
 
-const ALLOWED_SEGMENT = /^[A-Za-z0-9._() \-]+$/;
-
-function httpError(statusCode, message) {
-  const err = new Error(message);
-  err.statusCode = statusCode;
-  return err;
-}
-
-function reqJson(event) {
-  try { return JSON.parse(event.body || "{}"); } catch { return {}; }
-}
-
-function getEnv(name, required = true) {
-  const val = process.env[name];
-  if (required && (!val || !val.trim())) {
-    throw new Error(`Missing env ${name}`);
-  }
-  return val;
-}
-
-function normalizeSegment(name, value) {
-  if (value === undefined || value === null) {
-    return "";
-  }
-
-  const str = String(value).trim();
-  if (!str) {
-    return "";
-  }
-
-  if (!ALLOWED_SEGMENT.test(str)) {
-    throw httpError(400, `Invalid ${name}`);
-  }
-
-  return str;
-}
-
-function ensureSlugAllowed(slug) {
-  const envSlugRaw = process.env.PUBLIC_INVESTOR_SLUG;
-  if (!envSlugRaw) {
-    return slug;
-  }
-
-  const envSlug = String(envSlugRaw).trim();
-  if (!envSlug) {
-    return slug;
-  }
-
-  if (!ALLOWED_SEGMENT.test(envSlug)) {
-    return slug;
-  }
-
-  if (slug.toLowerCase() !== envSlug.toLowerCase()) {
-    throw httpError(403, "Slug not allowed");
-  }
-
-  return envSlug;
-}
-
-async function githubErrorMessage(response) {
-  let message = "GitHub upload error";
+export const handler = async (event) => {
   try {
-    const data = await response.json();
-    if (data?.message) {
-      message = `${message}: ${data.message}`;
-    }
-  } catch {
-    // ignore JSON parse errors
-  }
-  return message;
-}
+    if (event.httpMethod !== 'POST') return resp(405, { ok:false, code:'MethodNotAllowed' });
 
-function normalizePath(rawPath) {
-  return rawPath
-    .trim()
-    .replace(/\\+/g, "/")
-    .replace(/\/+/g, "/")
-    .replace(/^\/+|\/+$/g, "");
-}
+    // Parse multipart
+    const contentType = event.headers['content-type'] || event.headers['Content-Type'];
+    if (!contentType?.includes('multipart/form-data')) return resp(400, { ok:false, code:'BadRequest', msg:'Expected multipart/form-data' });
 
-async function githubRequest(url, options) {
-  const response = await fetch(url, options);
-  if (response.status === 401 || response.status === 403 || response.status === 422) {
-    let message = "GitHub upload error";
-    try {
-      const json = await response.json();
-      if (json?.message) {
-        message = `GitHub upload error: ${json.message}`;
-      }
-    } catch {
-      // ignore
-    }
-    throw httpError(500, message);
-  }
-  return response;
-}
+    const fields = {};
+    let fileBuf = Buffer.alloc(0);
+    let filename = '';
 
-export async function handler(event) {
-  if (event.httpMethod !== "POST") {
-    return { statusCode: 405, body: "Method Not Allowed" };
-  }
-
-  try {
-    const body = reqJson(event);
-
-    const rawPath = typeof body.path === "string" ? body.path : "";
-    const rawContentBase64 = typeof body.contentBase64 === "string" ? body.contentBase64 : "";
-
-    if (!rawContentBase64.trim()) {
-      throw httpError(400, "Missing contentBase64");
-    }
-
-    let category = "";
-    let slug = "";
-    let filename = "";
-
-    if (rawPath.trim()) {
-      const segments = rawPath
-        .replace(/\\/g, "/")
-        .split("/")
-        .map((segment) => segment.trim())
-        .filter((segment) => segment.length > 0);
-
-      if (segments.length !== 3) {
-        throw httpError(400, "Missing category/slug/filename");
-      }
-
-      category = normalizeSegment("category", segments[0]);
-      slug = normalizeSegment("slug", segments[1]);
-      filename = normalizeSegment("filename", segments[2]);
-    } else {
-      category = normalizeSegment("category", body.category);
-      slug = normalizeSegment("slug", body.slug);
-      filename = normalizeSegment("filename", body.filename);
-
-      if (!category || !slug || !filename) {
-        throw httpError(400, "Missing category/slug/filename");
-      }
-    }
-
-    if (!category || !slug || !filename) {
-      throw httpError(400, "Missing category/slug/filename");
-    }
-
-    slug = ensureSlugAllowed(slug);
-
-    const path = `${category}/${slug}/${filename}`;
-
-    const base64Body = rawContentBase64
-      .trim()
-      .replace(/^data:.*?;base64,/i, "")
-      .replace(/\s+/g, "");
-
-    if (!base64Body) {
-      throw httpError(400, "Invalid base64");
-    }
-
-    let binary;
-    try {
-      binary = Buffer.from(base64Body, "base64");
-    } catch {
-      throw httpError(400, "Invalid base64");
-    }
-
-    if (!binary || !binary.length) {
-      throw httpError(400, "Invalid base64");
-    }
-
-    const normalizedBase64 = binary.toString("base64");
-    const base64NoPad = normalizedBase64.replace(/=+$/g, "");
-    const inputNoPad = base64Body.replace(/=+$/g, "");
-    if (!base64Body || base64NoPad !== inputNoPad) {
-      throw httpError(400, "Invalid base64");
-    }
-
-    const DOCS_REPO = getEnv("DOCS_REPO");
-    const DOCS_BRANCH = getEnv("DOCS_BRANCH");
-    const GITHUB_TOKEN = getEnv("GITHUB_TOKEN");
-    const [owner, repo] = DOCS_REPO.split("/");
-
-    const encodedPath = path.split("/").map(encodeURIComponent).join("/");
-    const baseUrl = `https://api.github.com/repos/${owner}/${repo}/contents/${encodedPath}`;
-    const authHeaders = {
-      Authorization: `Bearer ${GITHUB_TOKEN}`,
-      Accept: "application/vnd.github.v3+json",
-    };
-
-    // Obtener sha si el archivo ya existe (para update)
-    let sha;
-    try {
-      const metadataResp = await githubRequest(`${baseUrl}?ref=${encodeURIComponent(DOCS_BRANCH)}`, {
-        method: "GET",
-        headers: authHeaders,
+    await new Promise((resolve, reject) => {
+      const bb = Busboy({ headers: { 'content-type': contentType } });
+      bb.on('field', (name, val) => fields[name] = String(val || '').trim());
+      bb.on('file', (_name, stream, info) => {
+        filename = info?.filename || '';
+        stream.on('data', d => fileBuf = Buffer.concat([fileBuf, d]));
       });
-
-      if (metadataResp.status === 200) {
-        const metadata = await metadataResp.json();
-        if (!Array.isArray(metadata) && metadata?.type === "file" && metadata?.sha) {
-          sha = metadata.sha;
-        } else {
-          throw httpError(404, "File not found");
-        }
-      } else if (metadataResp.status === 404) {
-        // Archivo nuevo, continuar sin sha
-      } else if ([401, 403, 422].includes(metadataResp.status)) {
-        throw httpError(500, await githubErrorMessage(metadataResp));
-      } else {
-        throw httpError(500, "GitHub upload error");
-      }
-    } catch (err) {
-      if (err.statusCode === 404) throw err;
-      if (err.statusCode) throw err;
-      throw httpError(500, "GitHub upload error");
-    }
-
-    const putBody = {
-      message: `chore(docs): upload ${path}`,
-      content: normalizedBase64,
-      branch: DOCS_BRANCH,
-    };
-    if (sha) putBody.sha = sha;
-
-    const putResp = await githubRequest(baseUrl, {
-      method: "PUT",
-      headers: { ...authHeaders, "Content-Type": "application/json" },
-      body: JSON.stringify(putBody),
+      bb.on('finish', resolve);
+      bb.on('error', reject);
+      bb.end(Buffer.from(event.body, event.isBase64Encoded ? 'base64' : 'utf8'));
     });
-    if (putResp.status !== 200 && putResp.status !== 201) {
-      if ([401, 403, 422].includes(putResp.status)) {
-        throw httpError(500, await githubErrorMessage(putResp));
-      }
 
-      throw httpError(500, await githubErrorMessage(putResp));
-    }
+    // Validaciones claras
+    const slug = (fields.slug || '').toLowerCase();
+    const category = (fields.category || '').trim();
+    const explicitFilename = (fields.filename || '').trim() || filename;
 
-    return {
-      statusCode: putResp.status,
-      body: JSON.stringify({ ok: true, path }),
-    };
+    if (!slug) return resp(400, { ok:false, code:'MissingField', field:'slug' });
+    if (slug !== 'alsea') return resp(403, { ok:false, code:'ForbiddenSlug', msg:'Solo Alsea permitido' });
+    if (!category) return resp(400, { ok:false, code:'MissingField', field:'category' });
+    if (!explicitFilename) return resp(400, { ok:false, code:'MissingField', field:'filename' });
+    if (!fileBuf.length) return resp(400, { ok:false, code:'MissingFile' });
+
+    // Limite práctico de GitHub (evitar base64 gigante)
+    const maxBytes = 25 * 1024 * 1024;
+    if (fileBuf.length > maxBytes) return resp(413, { ok:false, code:'FILE_TOO_LARGE_FOR_GITHUB', msg:'Usar almacenamiento alterno (Drive/S3)' });
+
+    const path = `data/docs/${slug}/${category}/${explicitFilename}`;
+    const contentBase64 = fileBuf.toString('base64');
+
+    const out = await putFileGithub({ path, contentBase64, message:`Upload: ${slug}/${category}/${explicitFilename}` });
+    return resp(200, { ok:true, provider:'github', path, ...out });
   } catch (err) {
-    const statusCode = err.statusCode || 500;
-    const message = err.message || "upload-doc error";
-    return { statusCode, body: message };
+    const msg = String(err?.message || err);
+    if (msg.startsWith('MissingEnv')) return resp(500, { ok:false, code:'MissingEnv', msg });
+    if (msg === 'NotFound') return resp(404, { ok:false, code:'NotFound' });
+    return resp(500, { ok:false, code:'UploadError', msg });
   }
+};
+
+function resp(statusCode, body) {
+  return {
+    statusCode,
+    headers: {
+      'Access-Control-Allow-Origin': '*',
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify(body)
+  };
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1700,6 +1700,7 @@
       "name": "dealroom-finsolar",
       "version": "0.1.0",
       "dependencies": {
+        "busboy": "^1.6.0",
         "octokit": "^4.0.2",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -1712,6 +1713,9 @@
     }
   },
   "dependencies": {
+    "busboy": {
+      "version": "^1.6.0"
+    },
     "octokit": {
       "version": "^4.0.2"
     },

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "busboy": "^1.6.0",
     "octokit": "^4.0.2",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -1,14 +1,22 @@
 async function req(path, {method='GET', body, headers} = {}){
-  const h = Object.assign({
-    'Content-Type': 'application/json'
-  }, headers || {})
-  const res = await fetch(path, { method, headers: h, body: body ? JSON.stringify(body) : undefined })
+  const isFormData = typeof FormData !== 'undefined' && body instanceof FormData
+  const h = Object.assign({}, headers || {})
+  if (!isFormData){
+    h['Content-Type'] = h['Content-Type'] || 'application/json'
+  }
+  const fetchOptions = { method, headers: h }
+  if (body !== undefined){
+    fetchOptions.body = isFormData ? body : JSON.stringify(body)
+  }
+  const res = await fetch(path, fetchOptions)
   const ct = res.headers.get('content-type') || ''
   const isJson = ct.includes('application/json')
   const payload = isJson ? await res.json().catch(() => null) : await res.text().catch(() => '')
   if (!res.ok){
     const message = isJson
-      ? (payload && typeof payload === 'object' ? (payload.message || payload.error || `${res.status} ${res.statusText}`) : `${res.status} ${res.statusText}`)
+      ? (payload && typeof payload === 'object'
+        ? (payload.message || payload.msg || payload.error || payload.code || `${res.status} ${res.statusText}`)
+        : `${res.status} ${res.statusText}`)
       : (typeof payload === 'string' && payload ? payload : `${res.status} ${res.statusText}`)
     const error = new Error(message)
     error.status = res.status
@@ -54,21 +62,48 @@ export const api = {
   calendarIcsUrl(slug){
     return `/.netlify/functions/calendar?slug=${encodeURIComponent(slug)}`
   },
-  downloadDocPath(relPath){
+  downloadDocPath(relPath, options = {}){
+    const disposition = (options && options.disposition) || 'attachment'
     const normalized = (relPath || '').replace(/^\/+/, '')
     const parts = normalized.split('/').filter(Boolean)
-    const slug = parts.length > 1 ? parts[1] : ''
+    if (parts.length >= 5 && parts[0] === 'data' && parts[1] === 'docs'){
+      const slug = parts[2]
+      const category = parts[3]
+      const filename = parts.slice(4).join('/')
+      return this.docDownloadUrl({ category, slug, filename, disposition })
+    }
+    if (parts.length >= 3){
+      const [category, slug, ...rest] = parts
+      const filename = rest.join('/')
+      if ((slug || '').toLowerCase() === 'alsea'){
+        return this.docDownloadUrl({ category, slug, filename, disposition })
+      }
+    }
+    const legacySlug = parts.length > 1 ? parts[1] : ''
     const params = new URLSearchParams()
     if (normalized) params.set('path', normalized)
-    if (slug) params.set('investor', slug)
+    if (legacySlug) params.set('investor', legacySlug)
     const qs = params.toString()
     return `/.netlify/functions/get-doc${qs ? `?${qs}` : ''}`
   },
-  docDownloadUrl({ category, slug, filename }){
+  docDownloadUrl({ category, slug, filename, disposition = 'attachment' }){
+    const normalizedSlug = (slug || '').trim().toLowerCase()
+    const normalizedCategory = (category || '').trim()
+    const normalizedFilename = filename === undefined || filename === null ? '' : String(filename)
+    const safeDisposition = disposition === 'inline' ? 'inline' : 'attachment'
+    if (normalizedSlug === 'alsea'){
+      const params = new URLSearchParams()
+      params.set('slug', 'alsea')
+      if (normalizedCategory) params.set('category', normalizedCategory)
+      if (normalizedFilename) params.set('filename', normalizedFilename)
+      params.set('disposition', safeDisposition)
+      const qs = params.toString()
+      return `/.netlify/functions/download-file${qs ? `?${qs}` : ''}`
+    }
     const params = new URLSearchParams()
-    if (category) params.set('category', category)
+    if (normalizedCategory) params.set('category', normalizedCategory)
     if (slug) params.set('slug', slug)
-    if (filename || filename === '') params.set('filename', String(filename))
+    if (normalizedFilename) params.set('filename', normalizedFilename)
     const qs = params.toString()
     return `/.netlify/functions/get-doc${qs ? `?${qs}` : ''}`
   },

--- a/src/pages/Documents.jsx
+++ b/src/pages/Documents.jsx
@@ -77,17 +77,29 @@ export default function Documents(){
     if (!uploadInfo) return null
     setError(null)
     setUploadingCategory(uploadInfo.category)
+    const file = uploadInfo.file
+    const rawSlug = uploadInfo.slug || ''
+    const slug = rawSlug.toLowerCase()
+    const filename = uploadInfo.filename || (file && file.name) || ''
     try{
-      const payload = {
-        category: uploadInfo.category,
-        slug: uploadInfo.slug,
-        filename: uploadInfo.filename,
-        contentBase64: uploadInfo.base64
+      if (!slug){
+        throw new Error('Slug no disponible para la carga')
       }
+      if (!file){
+        throw new Error('Selecciona un archivo para subir')
+      }
+      if (!filename){
+        throw new Error('El archivo no tiene nombre válido')
+      }
+      const formData = new FormData()
+      formData.set('slug', slug)
+      formData.set('category', uploadInfo.category)
+      formData.set('filename', filename)
+      formData.append('file', file, filename)
       if (options.strategy === 'rename'){
-        payload.strategy = 'rename'
+        formData.set('strategy', 'rename')
       }
-      const response = await api.uploadDoc(payload)
+      const response = await api.uploadDoc(formData)
       await refreshCategory(uploadInfo.category)
       const successMsg = options.strategy === 'rename'
         ? 'Documento subido con sufijo automático.'
@@ -99,12 +111,22 @@ export default function Documents(){
       return response
     }catch(err){
       if (err?.status === 409 && err?.data?.error === 'FILE_EXISTS' && options.strategy !== 'rename'){
-        const fallbackPath = `${uploadInfo.category}/${uploadInfo.slug}/${uploadInfo.filename}`
+        const normalizedSlug = slug || rawSlug
+        const safeFilename = filename || uploadInfo.filename || ''
+        const fallbackPath = `data/docs/${normalizedSlug}/${uploadInfo.category}/${safeFilename}`
         setPendingUpload(uploadInfo)
         setRenamePrompt({ path: err.data?.path || fallbackPath, category: uploadInfo.category })
         return null
       }
-      const message = err?.message || 'No se pudo subir el archivo'
+      const code = err?.data?.code
+      let message = err?.message || 'No se pudo subir el archivo'
+      if (code === 'MissingField' && err?.data?.field){
+        message = `Falta ${err.data.field}`
+      }else if (code === 'ForbiddenSlug'){
+        message = 'Solo se permiten cargas para Alsea'
+      }else if (code === 'FILE_TOO_LARGE_FOR_GITHUB'){
+        message = 'El archivo supera el límite de 25 MB'
+      }
       setError(message)
       showToast(message, { tone: 'error', duration: 5000 })
       return null
@@ -113,7 +135,7 @@ export default function Documents(){
     }
   }, [refreshCategory, showToast])
 
-  const handleUpload = useCallback((category) => (e) => {
+  const handleUpload = useCallback((category) => async (e) => {
     e.preventDefault()
     setError(null)
     setPendingUpload(null)
@@ -122,37 +144,20 @@ export default function Documents(){
     const fileInput = form.file
     const file = fileInput && fileInput.files ? fileInput.files[0] : null
     if (!file) return
-    const reader = new FileReader()
-    reader.onload = async () => {
-      try{
-        const result = typeof reader.result === 'string' ? reader.result : ''
-        const base64 = result.includes(',') ? result.split(',')[1] : result
-        if (!base64) throw new Error('No se pudo leer el archivo')
-        const uploadSlug = slugForDocs
-        if (!uploadSlug){
-          throw new Error('Slug no disponible para la carga')
-        }
-        await performUpload({
-          category,
-          filename: file.name,
-          base64,
-          slug: uploadSlug,
-          form
-        })
-      }catch(err){
-        const message = err?.message || 'No se pudo leer el archivo'
-        setError(message)
-        showToast(message, { tone: 'error', duration: 5000 })
-        setUploadingCategory(null)
-      }
-    }
-    reader.onerror = () => {
-      const message = 'No se pudo leer el archivo'
+    const uploadSlug = slugForDocs
+    if (!uploadSlug){
+      const message = 'Slug no disponible para la carga'
       setError(message)
       showToast(message, { tone: 'error', duration: 5000 })
-      setUploadingCategory(null)
+      return
     }
-    reader.readAsDataURL(file)
+    await performUpload({
+      category,
+      filename: file.name,
+      file,
+      slug: uploadSlug,
+      form
+    })
   }, [performUpload, showToast, slugForDocs])
 
   const handleConfirmRename = useCallback(async () => {
@@ -222,8 +227,10 @@ export default function Documents(){
                       const slugForKey = slugForDocs || normalizedInvestorId || investorId || 'default'
                       const key = d.path || `${category}/${slugForKey}/${filename}`
                       const href = isAlseaContext
-                        ? api.docDownloadUrl({ category, slug: alseaSlug, filename })
-                        : (d.path ? api.downloadDocPath(d.path) : api.docDownloadUrl({ category, slug: slugForDocs || '', filename }))
+                        ? api.docDownloadUrl({ category, slug: alseaSlug, filename, disposition: 'attachment' })
+                        : (d.path
+                          ? api.downloadDocPath(d.path, { disposition: 'attachment' })
+                          : api.docDownloadUrl({ category, slug: slugForDocs || '', filename, disposition: 'attachment' }))
                       return (
                         <tr key={key}>
                           <td>{filename}</td>


### PR DESCRIPTION
## Summary
- add a shared GitHub storage helper and new Netlify download endpoint restricted to the Alsea slug
- replace the upload function with multipart parsing, clearer validation, and GitHub-backed storage under data/docs/alsea
- update document listings and the React client to post multipart FormData, use the new download URLs, and add the busboy dependency

## Testing
- npm run build *(fails: vite is not installed in the offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68df1a06d32c832d9f63f7ce7e9390f5