### PR TITLE
feat: support isolated Alsea docs backend

### DIFF
--- a/netlify/functions/download-file.mjs
+++ b/netlify/functions/download-file.mjs
@@ -1,91 +1,59 @@
 // netlify/functions/download-file.mjs
 import { getGithubRawUrl } from "./lib/storage.js";
 
+const FF = process.env.DOCS_BACKEND_ALSEA === 'on';
+function json(statusCode, body){ return { statusCode, headers:{'Access-Control-Allow-Origin':process.env.CORS_ORIGIN||'*','Content-Type':'application/json'}, body: JSON.stringify(body) }; }
+function assertFeatureOn(){ if(!FF) throw new Error('Disabled'); }
+function assertAlsea(slug){ if((slug||'').toLowerCase()!=='alsea'){ const e=new Error('ForbiddenSlug'); e.code='ForbiddenSlug'; throw e; } }
+function assertSafe(value, field='field'){ if(!value){ const e=new Error('MissingParam'); e.code='MissingParam'; e.field=field; throw e; } if(value.length>100){ const e=new Error('BadRequest'); e.code='BadRequest'; throw e; } const ok=/^[a-zA-Z0-9._-]{1,100}$/.test(value); const bad=/(\.{2})|(\/)|(\\)|(%2e)|(%2f)|(%5c)/i.test(value); if(!ok||bad){ const e=new Error('BadRequest'); e.code='BadRequest'; throw e; } }
+function guessMime(ext){ const e=(ext||'').toLowerCase(); if (e==='pdf') return 'application/pdf'; if (['png','jpg','jpeg','gif','webp'].includes(e)) return `image/${e==='jpg'?'jpeg':e}`; if (e==='txt') return 'text/plain'; if (e==='csv') return 'text/csv'; if (['xls','xlsx'].includes(e)) return 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'; if (['doc','docx'].includes(e)) return 'application/vnd.openxmlformats-officedocument.wordprocessingml.document'; if (e==='zip') return 'application/zip'; return 'application/octet-stream'; }
+async function streamToBase64(stream){ const chunks=[]; const reader=stream.getReader(); for(;;){ const {done,value}=await reader.read(); if(done) break; chunks.push(value); } return Buffer.concat(chunks).toString('base64'); }
+
 export const handler = async (event) => {
   try {
-    if (event.httpMethod !== 'GET') return res(405, 'MethodNotAllowed');
+    assertFeatureOn();
+    if (event.httpMethod !== 'GET') return json(405, { ok:false, code:'MethodNotAllowed' });
 
     const q = event.queryStringParameters || {};
-    const slug = (q.slug || '').toLowerCase();
-    const category = (q.category || '').trim();
-    const filename = (q.filename || '').trim();
-    const disposition = (q.disposition || 'attachment').toLowerCase(); // 'inline' o 'attachment'
+    const slug = (q.slug||'').toLowerCase();
+    const category = (q.category||'').trim();
+    const filename = (q.filename||'').trim();
+    const disposition = ((q.disposition||'attachment').toLowerCase()==='inline') ? 'inline' : 'attachment';
 
-    if (!slug) return json(400, { ok:false, code:'MissingParam', param:'slug' });
-    if (slug !== 'alsea') return json(403, { ok:false, code:'ForbiddenSlug', msg:'Solo Alsea permitido' });
-    if (!category) return json(400, { ok:false, code:'MissingParam', param:'category' });
-    if (!filename) return json(400, { ok:false, code:'MissingParam', param:'filename' });
-    if (hasTraversal(category) || hasTraversal(filename)) {
-      return json(400, { ok:false, code:'InvalidPath', msg:'Nombre de archivo o categoría inválido' });
-    }
+    assertAlsea(slug);
+    assertSafe(slug,'slug'); assertSafe(category,'category'); assertSafe(filename,'filename');
 
     const path = `data/docs/${slug}/${category}/${filename}`;
     const { downloadUrl, size } = await getGithubRawUrl({ path });
-    if (!size || Number(size) <= 0) {
-      console.error('download-file.mjs:github-empty', { path, reportedSize: size });
-      return json(502, { ok:false, code:'EmptyFile', msg:'El archivo no tiene contenido' });
-    }
 
-    console.debug('download-file.mjs:github-metadata', { path, size });
-
-    // Detectar mimetype simple por extensión
-    const ext = filename.split('.').pop()?.toLowerCase();
+    const ext = filename.split('.').pop();
     const mimetype = guessMime(ext);
 
-    // Fetch con streaming (Node 18 fetch nativo)
     const upstream = await fetch(downloadUrl);
     if (!upstream.ok) return json(404, { ok:false, code:'NotFound' });
+    if (size === 0) return json(400, { ok:false, code:'CorruptFile' });
 
-    const body = upstream.body; // stream
+    const bodyBase64 = await streamToBase64(upstream.body);
 
     return {
       statusCode: 200,
       headers: {
-        'Access-Control-Allow-Origin': '*',
+        'Access-Control-Allow-Origin': process.env.CORS_ORIGIN || '*',
         'Content-Type': mimetype,
         ...(size ? { 'Content-Length': String(size) } : {}),
-        'Content-Disposition': `${disposition}; filename="${filename}"`
+        'Content-Disposition': `${disposition}; filename="${filename}"`,
       },
-      body: await streamToBase64(body),
-      isBase64Encoded: true
+      body: bodyBase64,
+      isBase64Encoded: true,
     };
+
   } catch (err) {
-    const msg = String(err?.message || err);
-    if (msg === 'NotFound') return json(404, { ok:false, code:'NotFound' });
-    if (msg.startsWith('MissingEnv')) return json(500, { ok:false, code:'MissingEnv', msg });
-    return json(500, { ok:false, code:'DownloadError', msg });
+    const code = err?.code || err?.message || 'DownloadError';
+    if (code==='Disabled') return json(503, { ok:false, code:'Disabled' });
+    if (code==='ForbiddenSlug') return json(403, { ok:false, code });
+    if (code==='MissingParam'||code==='BadRequest') return json(400, { ok:false, code, field: err?.field });
+    if (code==='NotFound') return json(404, { ok:false, code });
+    if (String(err?.message||'').startsWith('MissingEnv')) return json(500, { ok:false, code:'MissingEnv', msg: err.message });
+    return json(500, { ok:false, code:'DownloadError', msg: String(err?.message||err) });
   }
 };
-
-function guessMime(ext) {
-  if (ext === 'pdf') return 'application/pdf';
-  if (['png','jpg','jpeg','gif','webp'].includes(ext)) return `image/${ext==='jpg'?'jpeg':ext}`;
-  if (ext === 'txt') return 'text/plain';
-  if (ext === 'csv') return 'text/csv';
-  if (ext === 'json') return 'application/json';
-  if (['doc','docx'].includes(ext)) return 'application/vnd.openxmlformats-officedocument.wordprocessingml.document';
-  if (['xls','xlsx'].includes(ext)) return 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet';
-  if (ext === 'zip') return 'application/zip';
-  return 'application/octet-stream';
-}
-
-async function streamToBase64(stream) {
-  const chunks = [];
-  const reader = stream.getReader();
-  for (;;) {
-    const { done, value } = await reader.read();
-    if (done) break;
-    chunks.push(value);
-  }
-  const buf = Buffer.concat(chunks);
-  return buf.toString('base64');
-}
-
-function res(statusCode, msg) { return { statusCode, body: msg }; }
-function json(statusCode, obj) {
-  return {
-    statusCode,
-    headers: { 'Access-Control-Allow-Origin': '*', 'Content-Type': 'application/json' },
-    body: JSON.stringify(obj)
-  };
-}

--- a/netlify/functions/upload-doc.mjs
+++ b/netlify/functions/upload-doc.mjs
@@ -1,24 +1,27 @@
 // netlify/functions/upload-doc.mjs
-import { putFileGithub } from "./lib/storage.js";
 import Busboy from "busboy";
+import { putFileGithub } from "./lib/storage.js";
+
+const FF = process.env.DOCS_BACKEND_ALSEA === 'on';
+function json(statusCode, body){ return { statusCode, headers:{'Access-Control-Allow-Origin':process.env.CORS_ORIGIN||'*','Content-Type':'application/json'}, body: JSON.stringify(body) }; }
+function assertFeatureOn(){ if(!FF) throw new Error('Disabled'); }
+function assertAlsea(slug){ if((slug||'').toLowerCase()!=='alsea'){ const e=new Error('ForbiddenSlug'); e.code='ForbiddenSlug'; throw e; } }
+function assertSafe(value, field='field'){ if(!value){ const e=new Error('MissingField'); e.code='MissingField'; e.field=field; throw e; } if(value.length>100){ const e=new Error('BadRequest'); e.code='BadRequest'; throw e; } const ok=/^[a-zA-Z0-9._-]{1,100}$/.test(value); const bad=/(\.{2})|(\/)|(\\)|(%2e)|(%2f)|(%5c)/i.test(value); if(!ok||bad){ const e=new Error('BadRequest'); e.code='BadRequest'; throw e; } }
 
 export const handler = async (event) => {
   try {
-    if (event.httpMethod !== 'POST') return resp(405, { ok:false, code:'MethodNotAllowed' });
+    assertFeatureOn();
+    if (event.httpMethod !== 'POST') return json(405, { ok:false, code:'MethodNotAllowed' });
 
-    // Parse multipart
-    const contentType = event.headers['content-type'] || event.headers['Content-Type'];
-    if (!contentType?.includes('multipart/form-data')) return resp(400, { ok:false, code:'BadRequest', msg:'Expected multipart/form-data' });
+    const ct = event.headers['content-type']||event.headers['Content-Type']||'';
+    if (!ct.includes('multipart/form-data')) return json(400, { ok:false, code:'BadRequest', msg:'Expected multipart/form-data' });
 
-    const fields = {};
-    let fileBuf = Buffer.alloc(0);
-    let filename = '';
-
+    const fields = {}; let fileBuf = Buffer.alloc(0); let originalName = '';
     await new Promise((resolve, reject) => {
-      const bb = Busboy({ headers: { 'content-type': contentType } });
-      bb.on('field', (name, val) => fields[name] = String(val || '').trim());
+      const bb = Busboy({ headers: { 'content-type': ct } });
+      bb.on('field', (name, val) => fields[name] = String(val||'').trim());
       bb.on('file', (_name, stream, info) => {
-        filename = info?.filename || '';
+        originalName = info?.filename || '';
         stream.on('data', d => fileBuf = Buffer.concat([fileBuf, d]));
       });
       bb.on('finish', resolve);
@@ -26,41 +29,29 @@ export const handler = async (event) => {
       bb.end(Buffer.from(event.body, event.isBase64Encoded ? 'base64' : 'utf8'));
     });
 
-    // Validaciones claras
-    const slug = (fields.slug || '').toLowerCase();
-    const category = (fields.category || '').trim();
-    const explicitFilename = (fields.filename || '').trim() || filename;
+    const slug = (fields.slug||'').toLowerCase();
+    const category = (fields.category||'').trim();
+    const filename = (fields.filename||originalName||'').trim();
 
-    if (!slug) return resp(400, { ok:false, code:'MissingField', field:'slug' });
-    if (slug !== 'alsea') return resp(403, { ok:false, code:'ForbiddenSlug', msg:'Solo Alsea permitido' });
-    if (!category) return resp(400, { ok:false, code:'MissingField', field:'category' });
-    if (!explicitFilename) return resp(400, { ok:false, code:'MissingField', field:'filename' });
-    if (!fileBuf.length) return resp(400, { ok:false, code:'MissingFile' });
+    assertAlsea(slug);
+    assertSafe(slug,'slug'); assertSafe(category,'category'); assertSafe(filename,'filename');
 
-    // Limite práctico de GitHub (evitar base64 gigante)
+    if (!fileBuf.length) return json(400, { ok:false, code:'EmptyFile' });
     const maxBytes = 25 * 1024 * 1024;
-    if (fileBuf.length > maxBytes) return resp(413, { ok:false, code:'FILE_TOO_LARGE_FOR_GITHUB', msg:'Usar almacenamiento alterno (Drive/S3)' });
+    if (fileBuf.length > maxBytes) return json(413, { ok:false, code:'FILE_TOO_LARGE_FOR_GITHUB', msg:'Use almacenamiento alterno' });
 
-    const path = `data/docs/${slug}/${category}/${explicitFilename}`;
+    const path = `data/docs/${slug}/${category}/${filename}`;
     const contentBase64 = fileBuf.toString('base64');
 
-    const out = await putFileGithub({ path, contentBase64, message:`Upload: ${slug}/${category}/${explicitFilename}` });
-    return resp(200, { ok:true, provider:'github', path, ...out });
+    const out = await putFileGithub({ path, contentBase64, message:`Upload: ${slug}/${category}/${filename}` });
+    return json(200, { ok:true, provider:'github', path, ...out });
+
   } catch (err) {
-    const msg = String(err?.message || err);
-    if (msg.startsWith('MissingEnv')) return resp(500, { ok:false, code:'MissingEnv', msg });
-    if (msg === 'NotFound') return resp(404, { ok:false, code:'NotFound' });
-    return resp(500, { ok:false, code:'UploadError', msg });
+    const code = err?.code || err?.message || 'UploadError';
+    if (code==='Disabled') return json(503, { ok:false, code:'Disabled' });
+    if (code==='ForbiddenSlug') return json(403, { ok:false, code });
+    if (code==='MissingField'||code==='BadRequest') return json(400, { ok:false, code, field: err?.field });
+    if (String(err?.message||'').startsWith('MissingEnv')) return json(500, { ok:false, code:'MissingEnv', msg: err.message });
+    return json(500, { ok:false, code:'UploadError', msg: String(err?.message||err) });
   }
 };
-
-function resp(statusCode, body) {
-  return {
-    statusCode,
-    headers: {
-      'Access-Control-Allow-Origin': '*',
-      'Content-Type': 'application/json'
-    },
-    body: JSON.stringify(body)
-  };
-}

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -47,8 +47,9 @@ export const api = {
     const q = new URLSearchParams(params || {}).toString()
     return req(`/.netlify/functions/list-docs${q ? ('?'+q) : ''}`)
   },
-  async uploadDoc(info){
-    return req('/.netlify/functions/upload-doc', { method:'POST', body: info })
+  async uploadDoc(info, options = {}){
+    const endpoint = options.endpoint || '/.netlify/functions/upload-doc'
+    return req(endpoint, { method:'POST', body: info })
   },
   async deleteDoc(info){
     return req('/.netlify/functions/delete-doc', { method:'POST', body: info })
@@ -91,7 +92,8 @@ export const api = {
     const normalizedCategory = (category || '').trim()
     const normalizedFilename = filename === undefined || filename === null ? '' : String(filename)
     const safeDisposition = disposition === 'inline' ? 'inline' : 'attachment'
-    if (normalizedSlug === 'alsea'){
+    const isFeatureOn = import.meta.env?.VITE_DOCS_BACKEND_ALSEA === 'on'
+    if (normalizedSlug === 'alsea' && isFeatureOn){
       const params = new URLSearchParams()
       params.set('slug', 'alsea')
       if (normalizedCategory) params.set('category', normalizedCategory)
@@ -105,7 +107,7 @@ export const api = {
     if (slug) params.set('slug', slug)
     if (normalizedFilename) params.set('filename', normalizedFilename)
     const qs = params.toString()
-    return `/.netlify/functions/download-file${qs ? `?${qs}` : ''}`
+    return `/.netlify/functions/get-doc${qs ? `?${qs}` : ''}`
   },
   async listActivity(){
     return req('/.netlify/functions/list-activity')


### PR DESCRIPTION
## Summary
- enforce feature flag and slug validation in the Alsea upload/download Netlify functions with safer GitHub interactions
- add frontend logic to route Alsea document flows through the new endpoints while preserving legacy behaviour for other slugs
- improve admin and document UI messaging for empty uploads and disabled backend scenarios

## Testing
- npm run build *(fails: vite not found in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68df5efbfa34832dba5843f3dca5ce56