### PR TITLE
chore: migrate Netlify functions to ESM defaults

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -7,8 +7,7 @@
   NODE_VERSION = "18"
 
 [functions]
-  # Importante: no bundlear funciones; ejecutar ESM tal cual
-  node_bundler = "none"
+  node_bundler = "esbuild"
   # Incluye archivos adicionales si tu app los requiere
   included_files = ["data/**"]
 

--- a/netlify/functions/calendar.mjs
+++ b/netlify/functions/calendar.mjs
@@ -13,7 +13,7 @@ DESCRIPTION:${esc(description)}
 END:VEVENT`
 }
 
-export async function handler(event){
+export default async function handler(event, context){
   try{
     const slug = (event.queryStringParameters && event.queryStringParameters.slug) || 'femsa'
     const repo = process.env.CONTENT_REPO

--- a/netlify/functions/create-investor.mjs
+++ b/netlify/functions/create-investor.mjs
@@ -28,7 +28,7 @@ const isGitHubNotFound = (error) => {
   return message.includes('GitHub 404')
 }
 
-export async function handler(event){
+export default async function handler(event, context){
   try {
     if (event.httpMethod && event.httpMethod !== 'POST'){
       return json(405, { ok: false, error: 'Method not allowed' })

--- a/netlify/functions/delete-doc.mjs
+++ b/netlify/functions/delete-doc.mjs
@@ -5,7 +5,7 @@ function cleanPath(input = ''){
   return String(input).replace(/^\/+|\/+$/g, '')
 }
 
-export async function handler(event){
+export default async function handler(event, context){
   try{
     const body = JSON.parse(event.body || '{}')
     const relPath = cleanPath(body.path || '')

--- a/netlify/functions/delete-investor.mjs
+++ b/netlify/functions/delete-investor.mjs
@@ -49,7 +49,7 @@ async function deleteDirectoryRecursive(repo, path, branch){
   }
 }
 
-export async function handler(event){
+export default async function handler(event, context){
   if (event.httpMethod !== 'POST'){
     return text(405, 'Method not allowed')
   }

--- a/netlify/functions/download-file.mjs
+++ b/netlify/functions/download-file.mjs
@@ -1,24 +1,26 @@
 // netlify/functions/download-file.mjs
-import { getGithubFileBinary } from "./lib/storage.js";
+import { getGithubFileBinary } from "./lib/storage.mjs";
 
-// ...validaciones/slug/disposition/etc...
+export default async function handler(event, context) {
+  // ...validaciones/slug/disposition/etc...
 
-const path = `data/docs/${slug}/${category}/${filename}`;
+  const path = `data/docs/${slug}/${category}/${filename}`;
 
-// Antes: const { downloadUrl, size } = await getGithubRawUrl({ path });
-// Ahora:
-const { buffer, size } = await getGithubFileBinary({ path });
+  // Antes: const { downloadUrl, size } = await getGithubRawUrl({ path });
+  // Ahora:
+  const { buffer, size } = await getGithubFileBinary({ path });
 
-if (!buffer?.length) return json(400, { ok:false, code:'CorruptFile' });
+  if (!buffer?.length) return json(400, { ok:false, code:'CorruptFile' });
 
-return {
-  statusCode: 200,
-  headers: {
-    'Access-Control-Allow-Origin': process.env.CORS_ORIGIN || '*',
-    'Content-Type': mimetype,
-    ...(size ? { 'Content-Length': String(size) } : {}),
-    'Content-Disposition': `${disposition}; filename="${filename}"`
-  },
-  body: buffer.toString('base64'),
-  isBase64Encoded: true
-};
+  return {
+    statusCode: 200,
+    headers: {
+      'Access-Control-Allow-Origin': process.env.CORS_ORIGIN || '*',
+      'Content-Type': mimetype,
+      ...(size ? { 'Content-Length': String(size) } : {}),
+      'Content-Disposition': `${disposition}; filename="${filename}"`
+    },
+    body: buffer.toString('base64'),
+    isBase64Encoded: true
+  };
+}

--- a/netlify/functions/get-doc.mjs
+++ b/netlify/functions/get-doc.mjs
@@ -1,5 +1,5 @@
 // netlify/functions/get-doc.mjs
-import { getGithubFileBinary } from "./lib/storage.js";
+import { getGithubFileBinary } from "./lib/storage.mjs";
 
 const FF = process.env.DOCS_BACKEND_ALSEA === "on";
 
@@ -35,7 +35,7 @@ function guess(ext) {
   return "application/octet-stream";
 }
 
-export const handler = async (event) => {
+export default async function handler(event, context) {
   try {
     if (event.httpMethod !== "GET") return json(405, { ok:false, code:"MethodNotAllowed" });
 
@@ -87,4 +87,4 @@ export const handler = async (event) => {
     if (String(err?.message || "").startsWith("MissingEnv")) return json(500, { ok:false, code:"MissingEnv", msg: err.message });
     return json(500, { ok:false, code:"DownloadError", msg: String(err?.message || err) });
   }
-};
+}

--- a/netlify/functions/get-investor.mjs
+++ b/netlify/functions/get-investor.mjs
@@ -25,7 +25,7 @@ async function loadInvestor(slug){
   return loadInvestorFromRepo(repo, slug, branch)
 }
 
-export async function handler(event){
+export default async function handler(event, context){
   try {
     if (event.httpMethod && event.httpMethod !== 'GET'){
       return text(405, 'Method not allowed')

--- a/netlify/functions/list-activity.mjs
+++ b/netlify/functions/list-activity.mjs
@@ -116,7 +116,7 @@ async function loadDocEvents(){
   return events
 }
 
-export async function handler(){
+export default async function handler(event, context){
   try {
     // Si no hay token, no intentamos llamar a GitHub (evita 500 en deploy preview)
     if (!process.env.GITHUB_TOKEN){

--- a/netlify/functions/list-docs.mjs
+++ b/netlify/functions/list-docs.mjs
@@ -8,7 +8,7 @@ function sanitizeSegment(value){
     .trim()
 }
 
-export async function handler(event){
+export default async function handler(event, context){
   try{
     const categoryParam = event.queryStringParameters && event.queryStringParameters.category
     const slugParam = event.queryStringParameters && event.queryStringParameters.slug

--- a/netlify/functions/list-investors.mjs
+++ b/netlify/functions/list-investors.mjs
@@ -3,7 +3,7 @@ import { decodeIndexContent } from './_lib/investor-index.mjs'
 
 const collator = new Intl.Collator('es', { sensitivity: 'base' })
 
-export async function handler(){
+export default async function handler(event, context){
   try{
     const data = await readLocalJson('data/investor-index.json')
     const { entries } = decodeIndexContent(data)

--- a/netlify/functions/list-projects.mjs
+++ b/netlify/functions/list-projects.mjs
@@ -1,6 +1,6 @@
 import { ok, text, readLocalJson } from './_lib/utils.mjs'
 
-export async function handler(){
+export default async function handler(event, context){
   try{
     const items = await readLocalJson('data/projects.json')
     return ok(items)

--- a/netlify/functions/save-projects.mjs
+++ b/netlify/functions/save-projects.mjs
@@ -106,7 +106,7 @@ function normalizeProject(project, index){
   return normalized
 }
 
-export async function handler(event){
+export default async function handler(event, context){
   try{
     const body = JSON.parse(event.body || '{}')
     const list = body.projects

--- a/netlify/functions/update-investor.mjs
+++ b/netlify/functions/update-investor.mjs
@@ -15,7 +15,7 @@ const decodeFileContent = (file) => {
   return Buffer.from(file.content || '', encoding).toString('utf-8')
 }
 
-export async function handler(event){
+export default async function handler(event, context){
   try {
     if (event.httpMethod && event.httpMethod !== 'POST'){
       return json(405, { ok: false, error: 'Method not allowed' })

--- a/netlify/functions/update-status.mjs
+++ b/netlify/functions/update-status.mjs
@@ -2,7 +2,7 @@ import { Buffer } from 'node:buffer'
 import { ok, text } from './_lib/utils.mjs'
 import { repoEnv, getFile, putFile } from './_lib/github.mjs'
 
-export async function handler(event){
+export default async function handler(event, context){
   try{
     const body = JSON.parse(event.body || '{}')
     const normalizedId = typeof body.id === 'string'

--- a/netlify/functions/upload-doc.mjs
+++ b/netlify/functions/upload-doc.mjs
@@ -1,6 +1,6 @@
 // netlify/functions/upload-doc.mjs
 import Busboy from "busboy";
-import { putFileGithub } from "./lib/storage.js";
+import { putFileGithub } from "./lib/storage.mjs";
 
 const FF = process.env.DOCS_BACKEND_ALSEA === 'on';
 function json(statusCode, body){ return { statusCode, headers:{'Access-Control-Allow-Origin':process.env.CORS_ORIGIN||'*','Content-Type':'application/json'}, body: JSON.stringify(body) }; }
@@ -8,7 +8,7 @@ function assertFeatureOn(){ if(!FF) throw new Error('Disabled'); }
 function assertAlsea(slug){ if((slug||'').toLowerCase()!=='alsea'){ const e=new Error('ForbiddenSlug'); e.code='ForbiddenSlug'; throw e; } }
 function assertSafe(value, field='field'){ if(!value){ const e=new Error('MissingField'); e.code='MissingField'; e.field=field; throw e; } if(value.length>100){ const e=new Error('BadRequest'); e.code='BadRequest'; throw e; } const ok=/^[a-zA-Z0-9._-]{1,100}$/.test(value); const bad=/(\.{2})|(\/)|(\\)|(%2e)|(%2f)|(%5c)/i.test(value); if(!ok||bad){ const e=new Error('BadRequest'); e.code='BadRequest'; throw e; } }
 
-export const handler = async (event) => {
+export default async function handler(event, context) {
   try {
     assertFeatureOn();
     if (event.httpMethod !== 'POST') return json(405, { ok:false, code:'MethodNotAllowed' });
@@ -54,4 +54,4 @@ export const handler = async (event) => {
     if (String(err?.message||'').startsWith('MissingEnv')) return json(500, { ok:false, code:'MissingEnv', msg: err.message });
     return json(500, { ok:false, code:'UploadError', msg: String(err?.message||err) });
   }
-};
+}

--- a/package.json
+++ b/package.json
@@ -3,7 +3,9 @@
   "version": "0.1.0",
   "private": true,
   "type": "module",
-  "engines": { "node": ">=18" },
+  "engines": {
+    "node": ">=18"
+  },
   "scripts": {
     "dev": "vite",
     "build": "vite build",


### PR DESCRIPTION
## Summary
- convert Netlify Functions to default-exported ESM handlers and update related imports
- configure the project for Node 18+ ESM execution and enable esbuild bundling in Netlify

## Testing
- npm run build *(fails: `vite` command missing because npm install is blocked in the environment)*
- npx netlify dev *(fails: Netlify CLI package cannot be fetched due to 403 from registry)*

------
https://chatgpt.com/codex/tasks/task_e_68df7389e5e8832da8adca3eec644d38