### PR TITLE
Add shared HTTP, slug, and GitHub helper modules

### DIFF
--- a/netlify/functions/_shared/github.mjs
+++ b/netlify/functions/_shared/github.mjs
@@ -1,0 +1,62 @@
+import { Buffer } from 'node:buffer'
+import { Octokit } from 'octokit'
+
+export const octokit = new Octokit({
+  auth: process.env.GITHUB_TOKEN,
+})
+
+export const owner = process.env.DOCS_OWNER || 'finsolar'
+export const repo = process.env.DOCS_REPO || 'dealroom'
+export const ref = process.env.DOCS_REF || 'main'
+
+export async function listRepoPath(path) {
+  const { data } = await octokit.rest.repos.getContent({ owner, repo, path, ref })
+  return data
+}
+
+export async function getFileBuffer(path) {
+  const { data } = await octokit.rest.repos.getContent({ owner, repo, path, ref })
+  if (Array.isArray(data)) {
+    throw new Error('Requested path is not a file')
+  }
+
+  if (data.download_url) {
+    const response = await fetch(data.download_url)
+    const arrayBuffer = await response.arrayBuffer()
+    return Buffer.from(arrayBuffer)
+  }
+
+  const encoding = data.encoding || 'base64'
+  return Buffer.from(data.content, encoding)
+}
+
+export async function putFileBuffer(path, buffer, message, contentType = 'application/octet-stream') {
+  let sha
+  try {
+    const existing = await octokit.rest.repos.getContent({ owner, repo, path, ref })
+    if (!Array.isArray(existing.data)) {
+      sha = existing.data.sha
+    }
+  } catch (error) {
+    if (error.status !== 404) throw error
+  }
+
+  const base64Content = buffer.toString('base64')
+
+  const endpoint = octokit.request.endpoint('PUT /repos/{owner}/{repo}/contents/{path}', {
+    owner,
+    repo,
+    path,
+    message,
+    content: base64Content,
+    branch: ref,
+    ...(sha ? { sha } : {}),
+  })
+
+  endpoint.headers = {
+    ...endpoint.headers,
+    'Content-Type': contentType,
+  }
+
+  return octokit.request(endpoint)
+}

--- a/netlify/functions/_shared/http.mjs
+++ b/netlify/functions/_shared/http.mjs
@@ -1,48 +1,44 @@
 import { Buffer } from 'node:buffer'
 
 export function json(data, init = {}) {
-  const status = init.status ?? 200;
-  const headers = new Headers(init.headers || {});
-  if (!headers.has('Content-Type')) headers.set('Content-Type', 'application/json');
-  return new Response(JSON.stringify(data), { status, headers });
+  const status = init.status ?? 200
+  const headers = new Headers(init.headers || {})
+  if (!headers.has('Content-Type')) headers.set('Content-Type', 'application/json')
+  return new Response(JSON.stringify(data), { status, headers })
 }
 
 export function errorJson(message, status = 500, extra = {}) {
-  return json({ ok: false, error: message, ...extra }, { status });
+  return json({ ok: false, error: message, ...extra }, { status })
 }
 
 export function badRequest(message = 'Bad Request', extra = {}) {
-  return errorJson(message, 400, extra);
+  return errorJson(message, 400, extra)
 }
 
 export function notFound(message = 'Not Found', extra = {}) {
-  return errorJson(message, 404, extra);
+  return errorJson(message, 404, extra)
 }
 
 export function methodNotAllowed(allowed = ['GET']) {
-  return json({ ok: false, error: 'Method not allowed', allowed }, { status: 405 });
+  return json({ ok: false, error: 'Method not allowed', allowed }, { status: 405 })
 }
 
 export function binary(body, { filename, contentType = 'application/octet-stream', disposition = 'attachment', status = 200, headers: extraHeaders = {} } = {}) {
-  const headers = new Headers(extraHeaders);
-  headers.set('Content-Type', contentType);
-  if (filename) headers.set('Content-Disposition', `${disposition}; filename="${filename}"`);
-  return new Response(body, { status, headers });
+  const headers = new Headers(extraHeaders)
+  headers.set('Content-Type', contentType)
+  if (filename) headers.set('Content-Disposition', `${disposition}; filename="${filename}"`)
+  return new Response(body, { status, headers })
 }
 
 export function getUrlAndParams(request) {
-  const url = new URL(request.url);
-  return { url, params: url.searchParams };
+  const url = new URL(request.url)
+  return { url, params: url.searchParams }
 }
 
 export async function readSingleFileFromFormData(request) {
-  const form = await request.formData();
-  const file = form.get('file');
-  if (!file) return { form, file: null, buffer: null };
-  const arrayBuffer = await file.arrayBuffer();
-  return { form, file, buffer: Buffer.from(arrayBuffer) };
-}
-
-export function base64ToBuffer(b64) {
-  return Buffer.from(b64, 'base64');
+  const form = await request.formData()
+  const file = form.get('file')
+  if (!file) return { form, file: null, buffer: null }
+  const arrayBuffer = await file.arrayBuffer()
+  return { form, file, buffer: Buffer.from(arrayBuffer) }
 }

--- a/netlify/functions/_shared/slug.mjs
+++ b/netlify/functions/_shared/slug.mjs
@@ -1,0 +1,23 @@
+export function ensureSlugAllowed(inputSlug) {
+  const slug = inputSlug ?? ''
+  const allowed = new Set()
+
+  const singleSlug = process.env.PUBLIC_INVESTOR_SLUG?.trim()
+  if (singleSlug) allowed.add(singleSlug)
+
+  const multipleSlugs = process.env.PUBLIC_INVESTOR_SLUGS?.split(',') ?? []
+  for (const slug of multipleSlugs) {
+    const trimmed = slug.trim()
+    if (trimmed) allowed.add(trimmed)
+  }
+
+  if (allowed.size === 0) return slug
+
+  if (!allowed.has(slug)) {
+    const error = new Error('ForbiddenSlug')
+    error.statusCode = 403
+    throw error
+  }
+
+  return slug
+}


### PR DESCRIPTION
## Summary
- update the shared HTTP utilities to export the required helpers for Netlify functions
- add a slug allow-list validator that enforces PUBLIC_INVESTOR_SLUG(S) configuration
- create GitHub helper utilities for listing, fetching, and updating repository content via Octokit

## Testing
- npm run build *(fails: vite not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e02ca009b8832da8a5fac289a487f0