### PR TITLE
Add Netlify function for listing document categories

### DIFF
--- a/netlify/functions/list-categories.mjs
+++ b/netlify/functions/list-categories.mjs
@@ -1,0 +1,49 @@
+import { listRepoPath } from './_shared/github.mjs'
+import { getUrlAndParams, json, badRequest, notFound, methodNotAllowed, errorJson } from './_shared/http.mjs'
+import { ensureSlugAllowed } from './_shared/slug.mjs'
+
+export default async function handler(request) {
+  if (request.method && request.method.toUpperCase() !== 'GET') {
+    return methodNotAllowed(['GET'])
+  }
+
+  try {
+    const { params } = getUrlAndParams(request)
+    const slugParam = params.get('slug')
+
+    if (!slugParam) {
+      return badRequest('Missing slug')
+    }
+
+    const slug = ensureSlugAllowed(slugParam.trim())
+    const path = `docs/${slug}`
+
+    let items
+    try {
+      items = await listRepoPath(path)
+    } catch (error) {
+      if (error?.status === 404) {
+        return notFound('No categories found')
+      }
+      throw error
+    }
+
+    const categories = items
+      .filter((item) => item && item.type === 'dir')
+      .map((item) => item.name)
+
+    if (categories.length === 0) {
+      return notFound('No categories found')
+    }
+
+    return json({ ok: true, slug, categories })
+  } catch (error) {
+    if (error?.message === 'ForbiddenSlug' || error?.statusCode === 403 || error?.status === 403) {
+      return errorJson('ForbiddenSlug', 403)
+    }
+
+    const status = error?.statusCode || error?.status || 500
+    const message = status === 500 ? 'Internal error' : error?.message || 'Error'
+    return errorJson(message, status)
+  }
+}


### PR DESCRIPTION
## Summary
- add a Netlify function that lists category folders for a requested slug
- validate the slug against the allowed list and handle missing or empty directories
- return proper HTTP status codes for bad requests, forbidden slugs, and missing categories

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e030233328832d9006895691bed0f3