### PR TITLE
Use resolved investor slug for document API calls

### DIFF
--- a/src/lib/slug.js
+++ b/src/lib/slug.js
@@ -1,0 +1,6 @@
+export function resolveInvestorSlug() {
+  const qs = new URLSearchParams(window.location.search).get('slug');
+  if (qs && qs.trim()) return qs.trim().toLowerCase();
+  const env = import.meta.env.VITE_PUBLIC_INVESTOR_ID || '';
+  return env.trim().toLowerCase();
+}


### PR DESCRIPTION
## Summary
- add a shared helper to resolve the investor slug from the URL or environment
- ensure document API helpers default to the resolved slug when none is provided
- update the Documents page to consume the resolved slug and handle missing values gracefully

## Testing
- npm run build *(fails: vite not found because dependencies are not installed in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e03b419698832da0fe7450521c3e82