### PR TITLE
Add CORS headers to document Netlify functions

### DIFF
--- a/netlify/functions/_shared/http.mjs
+++ b/netlify/functions/_shared/http.mjs
@@ -1,33 +1,33 @@
 import { Buffer } from 'node:buffer'
 
 export function json(data, init = {}) {
-  const status = init.status ?? 200
   const headers = new Headers(init.headers || {})
   if (!headers.has('Content-Type')) headers.set('Content-Type', 'application/json')
-  return new Response(JSON.stringify(data), { status, headers })
+  const status = init.status ?? 200
+  return new Response(JSON.stringify(data), { ...init, status, headers })
 }
 
-export function errorJson(message, status = 500, extra = {}) {
-  return json({ ok: false, error: message, ...extra }, { status })
+export function errorJson(message, status = 500, extra = {}, init = {}) {
+  return json({ ok: false, error: message, ...extra }, { ...init, status })
 }
 
-export function badRequest(message = 'Bad Request', extra = {}) {
-  return errorJson(message, 400, extra)
+export function badRequest(message = 'Bad Request', extra = {}, init = {}) {
+  return errorJson(message, 400, extra, init)
 }
 
-export function notFound(message = 'Not Found', extra = {}) {
-  return errorJson(message, 404, extra)
+export function notFound(message = 'Not Found', extra = {}, init = {}) {
+  return errorJson(message, 404, extra, init)
 }
 
-export function methodNotAllowed(allowed = ['GET']) {
-  return json({ ok: false, error: 'Method not allowed', allowed }, { status: 405 })
+export function methodNotAllowed(allowed = ['GET'], init = {}) {
+  return json({ ok: false, error: 'Method not allowed', allowed }, { ...init, status: 405 })
 }
 
-export function binary(body, { filename, contentType = 'application/octet-stream', disposition = 'attachment', status = 200, headers: extraHeaders = {} } = {}) {
+export function binary(body, { filename, contentType = 'application/octet-stream', disposition = 'attachment', status = 200, headers: extraHeaders = {}, ...init } = {}) {
   const headers = new Headers(extraHeaders)
   headers.set('Content-Type', contentType)
   if (filename) headers.set('Content-Disposition', `${disposition}; filename="${filename}"`)
-  return new Response(body, { status, headers })
+  return new Response(body, { ...init, status, headers })
 }
 
 export function getUrlAndParams(request) {


### PR DESCRIPTION
## Summary
- allow the shared HTTP helpers to merge custom headers into responses
- add configurable CORS headers and preflight handling to the document upload and download functions

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e0422b4e00832d885ffa7cfe9da371