### PR TITLE
Implement dual-path docs listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,12 +70,13 @@ VITE_PUBLIC_INVESTOR_ID=femsa
 ```
 
 > Sin `GITHUB_TOKEN`, el sitio funciona en modo demo (lee `/data` local y no lista documentos).
+> Para habilitar el backend de documentos asegúrate de definir `DOCS_REPO`, `DOCS_BRANCH` y `GITHUB_TOKEN`, y de dejar apagada la bandera `DOCS_BACKEND_ALSEA` (sin definir o distinta de `on`). Puedes fijar un único slug público con `PUBLIC_INVESTOR_SLUG`.
 
 ---
 
 ## 5) Flujo de documentos (solo GitHub + Netlify)
 
-- **Listar:** `/.netlify/functions/list-docs?category=NDA` devuelve archivos en `data/docs/<slug>/<Categoría>/`.
+- **Listar:** `/.netlify/functions/list-docs?category=NDA` busca primero en `<Categoría>/<slug>/` (esquema nuevo) y, si no existe, intenta `data/docs/<slug>/<Categoría>/` (esquema legado). Si ambas rutas existen, combina los archivos sin duplicados.
 - **Subir:** UI de `/documents` llama `upload-doc` → commit al repo de documentos.
 - **Descargar:** `download-file` entrega el archivo desde GitHub (inline o attachment) para el slug permitido.
   - Valida que la metadata de GitHub reporte tamaño > 0 y que el binario descargado tenga contenido antes de regresarlo al navegador.


### PR DESCRIPTION
## Summary
- adjust the list-docs function to look for files in the new `<category>/<slug>` layout while falling back to the legacy `data/docs/<slug>/<category>` structure
- deduplicate files across both directories and always return an `{ ok: true, files: [...] }` payload when listing completes
- document the required environment variables and the need to keep the legacy Alsea flag disabled in the README

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e050c89920832db56608c67084930c